### PR TITLE
Include LICENSE and doc files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.rst
+include *.txt


### PR DESCRIPTION
This adds LICENSE and the documentation files to
the source tarball generated by setuptools.

The LICENSE text is important for packaging this
library into the Fedora distribution.