### PR TITLE
[GH-19]Make sure thread-safe for get of sqlqueue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,6 @@ Example usage with a SQLite3 based dict
     >>> q = PDict("testpath", "testname")
     >>> q['key1'] = 123
     >>> q['key2'] = 321
-    >>> q['key1'] = 123
-    >>> q['key2'] = 321
     >>> q['key1']
     123
     >>> len(q)

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -60,6 +60,7 @@ class SQLiteBase(object):
                 self.path, self.multithreading, self.timeout)
         self._conn.execute(self._sql_create)
         self._conn.commit()
+        # SQLite3 transaction lock
         self.tran_lock = threading.Lock()
         self.put_event = threading.Event()
 


### PR DESCRIPTION
The `get` previously is not atomic since it contains 2 sql, a
select and a update. This patch will add a lock for the get operation
for data synchronization.