### PR TITLE
Performance optimization for sqlite3 based queue

### DIFF
--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -1,0 +1,153 @@
+"""This file provides tests to benchmark performance sqlite/file queue
+on specific hardware. User can easily evaluate the performance by running this
+file directly via `python run_benchmark.py`
+"""
+from persistqueue import SQLiteQueue
+from persistqueue import Queue
+import tempfile
+import time
+
+BENCHMARK_COUNT = 100
+
+
+def time_it(func):
+    def _exec(*args, **kwargs):
+        start = time.time()
+        func(*args, **kwargs)
+        end = time.time()
+        print(
+            "\t{} => time used: {:.4f} seconds.".format(
+                func.__doc__,
+                (end - start)))
+
+    return _exec
+
+
+class TransactionBench(object):
+    """Benchmark transaction write/read."""
+
+    def __init__(self, prefix=None):
+        self.path = prefix
+
+    @time_it
+    def benchmark_sqlite_write_10000(self):
+        """Benchmark sqlite queue by writing <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_sql_10000')
+        q = SQLiteQueue(self.path, auto_commit=True)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+
+    @time_it
+    def benchmark_sqlite_wr_10000(self):
+        """Benchmark sqlite queue by writing and reading <BENCHMARK_COUNT> items."""
+        self.path = tempfile.mkdtemp('b_sql_10000')
+        q = SQLiteQueue(self.path, auto_commit=True)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+
+        for i in range(BENCHMARK_COUNT):
+            q.get()
+
+    @time_it
+    def benchmark_file_write_10000(self):
+        """Benchmark file queue by writing <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_file_10000')
+        q = Queue(self.path)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+            q.task_done()
+
+    @time_it
+    def benchmark_file_wr_10000(self):
+        """Benchmark file queue by writing and reading <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_file_10000')
+        q = Queue(self.path)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+            q.task_done()
+
+        for i in range(BENCHMARK_COUNT):
+            q.get()
+
+    @classmethod
+    def run(cls):
+        print(cls.__doc__)
+        ins = cls()
+        for name in sorted(cls.__dict__):
+            if name.startswith('benchmark'):
+                func = getattr(ins, name)
+                func()
+
+
+class BulkBench(object):
+    """Benchmark bulk write/read."""
+
+    @time_it
+    def benchmark_sqlite_write_10000(self):
+        """Benchmark sqlite queue by writing <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_sql_10000')
+        q = SQLiteQueue(self.path, auto_commit=False)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+        q.task_done()
+
+    @time_it
+    def benchmark_sqlite_wr_10000(self):
+        """Benchmark sqlite queue by writing and reading <BENCHMARK_COUNT> items."""
+        self.path = tempfile.mkdtemp('b_sql_10000')
+        q = SQLiteQueue(self.path, auto_commit=False)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+        q.task_done()
+
+        for i in range(BENCHMARK_COUNT):
+            q.get()
+
+    @time_it
+    def benchmark_file_write_10000(self):
+        """Benchmark file queue by writing <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_file_10000')
+        q = Queue(self.path)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+        q.task_done()
+
+    @time_it
+    def benchmark_file_wr_10000(self):
+        """Benchmark file queue by writing and reading <BENCHMARK_COUNT> items."""
+
+        self.path = tempfile.mkdtemp('b_file_10000')
+        q = Queue(self.path)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+        q.task_done()
+
+        for i in range(BENCHMARK_COUNT):
+            q.get()
+
+    @classmethod
+    def run(cls):
+        print(cls.__doc__)
+        ins = cls()
+        for name in sorted(cls.__dict__):
+
+            if name.startswith('benchmark'):
+                func = getattr(ins, name)
+                func()
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) > 1:
+        BENCHMARK_COUNT = int(sys.argv[1])
+    print("<BENCHMARK_COUNT> = {}".format(BENCHMARK_COUNT))
+    transaction = TransactionBench()
+    transaction.run()
+    bulk = BulkBench()
+    bulk.run()

--- a/persistqueue/__init__.py
+++ b/persistqueue/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 __author__ = 'Peter Wang'
 __license__ = 'BSD License'
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 from .exceptions import Empty, Full  # noqa
 from .pdict import PDict  # noqa

--- a/persistqueue/pdict.py
+++ b/persistqueue/pdict.py
@@ -18,8 +18,10 @@ class PDict(sqlbase.SQLiteBase, dict):
     _SQL_UPDATE = 'UPDATE {table_name} SET data = ? WHERE {key_column} = ?'
 
     def __init__(self, path, name, multithreading=False):
+        # PDict is always auto_commit=True
         super(PDict, self).__init__(path, name=name,
-                                    multithreading=multithreading)
+                                    multithreading=multithreading,
+                                    auto_commit=True)
 
     def __iter__(self):
         raise NotImplementedError('Not supported.')

--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-"""A single process, persistent multi-producer, multi-consumer queue."""
+"""A thread-safe disk based persistent queue in Python."""
 
 import logging
 import os

--- a/tests/test_sqlqueue.py
+++ b/tests/test_sqlqueue.py
@@ -7,20 +7,37 @@ import unittest
 from threading import Thread
 
 from persistqueue import SQLiteQueue, FILOSQLiteQueue
+from persistqueue import Empty
+
+
+def task_done_if_required(queue):
+    if not queue.auto_commit:
+        queue.task_done()
 
 
 class SQLite3QueueTest(unittest.TestCase):
     def setUp(self):
         self.path = tempfile.mkdtemp(suffix='sqlqueue')
+        self.auto_commit = False
 
     def tearDown(self):
         shutil.rmtree(self.path, ignore_errors=True)
 
+    def test_raise_empty(self):
+        q = SQLiteQueue(self.path, auto_commit=self.auto_commit)
+
+        q.put('first')
+        task_done_if_required(q)
+        d = q.get()
+        self.assertEqual('first', d)
+        self.assertRaises(Empty, q.get, block=True)
+
     def test_open_close_single(self):
         """Write 1 item, close, reopen checking if same item is there"""
 
-        q = SQLiteQueue(self.path)
+        q = SQLiteQueue(self.path, auto_commit=self.auto_commit)
         q.put(b'var1')
+        task_done_if_required(q)
         del q
         q = SQLiteQueue(self.path)
         self.assertEqual(1, q.qsize())
@@ -29,9 +46,12 @@ class SQLite3QueueTest(unittest.TestCase):
     def test_open_close_1000(self):
         """Write 1000 items, close, reopen checking if all items are there"""
 
-        q = SQLiteQueue(self.path)
+        q = SQLiteQueue(self.path, auto_commit=self.auto_commit)
         for i in range(1000):
             q.put('var%d' % i)
+
+        task_done_if_required(q)
+
         self.assertEqual(1000, q.qsize())
         del q
         q = SQLiteQueue(self.path)
@@ -47,7 +67,7 @@ class SQLite3QueueTest(unittest.TestCase):
     def test_random_read_write(self):
         """Test random read/write"""
 
-        q = SQLiteQueue(self.path)
+        q = SQLiteQueue(self.path, auto_commit=self.auto_commit)
         n = 0
         for i in range(1000):
             if random.random() < 0.5:
@@ -58,6 +78,7 @@ class SQLite3QueueTest(unittest.TestCase):
                     self.assertEqual(None, q.get())
             else:
                 q.put('var%d' % random.getrandbits(16))
+                task_done_if_required(q)
                 n += 1
 
     def test_multi_threaded_parallel(self):
@@ -65,11 +86,14 @@ class SQLite3QueueTest(unittest.TestCase):
 
         # self.skipTest("Not supported multi-thread.")
 
-        m_queue = SQLiteQueue(path=self.path, multithreading=True)
+        m_queue = SQLiteQueue(path=self.path, multithreading=True,
+                              auto_commit=self.auto_commit)
 
         def producer():
             for i in range(1000):
                 m_queue.put('var%d' % i)
+
+            task_done_if_required(m_queue)
 
         def consumer():
             for i in range(1000):
@@ -88,11 +112,14 @@ class SQLite3QueueTest(unittest.TestCase):
 
     def test_multi_threaded_multi_producer(self):
         """Test sqlqueue can be used by multiple producers."""
-        queue = SQLiteQueue(path=self.path, multithreading=True)
+        queue = SQLiteQueue(path=self.path, multithreading=True,
+                            auto_commit=self.auto_commit)
 
         def producer(seq):
             for i in range(10):
                 queue.put('var%d' % (i + (seq * 10)))
+
+            task_done_if_required(queue)
 
         def consumer():
             for i in range(100):
@@ -115,11 +142,13 @@ class SQLite3QueueTest(unittest.TestCase):
     def test_multiple_consumers(self):
         """Test sqlqueue can be used by multiple consumers."""
 
-        queue = SQLiteQueue(path=self.path, multithreading=True)
+        queue = SQLiteQueue(path=self.path, multithreading=True,
+                            auto_commit=self.auto_commit)
 
         def producer():
             for x in range(1000):
                 queue.put('var%d' % x)
+                task_done_if_required(queue)
 
         def consumer():
             for _ in range(100):
@@ -140,9 +169,16 @@ class SQLite3QueueTest(unittest.TestCase):
         self.assertEqual(0, queue.qsize())
 
 
+class SQLite3QueueAutoCommitTest(SQLite3QueueTest):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='sqlqueue_auto_commit')
+        self.auto_commit = True
+
+
 class FILOSQLite3QueueTest(unittest.TestCase):
     def setUp(self):
         self.path = tempfile.mkdtemp(suffix='filo_sqlqueue')
+        self.auto_commit = False
 
     def tearDown(self):
         shutil.rmtree(self.path, ignore_errors=True)
@@ -150,9 +186,10 @@ class FILOSQLite3QueueTest(unittest.TestCase):
     def test_open_close_1000(self):
         """Write 1000 items, close, reopen checking if all items are there"""
 
-        q = FILOSQLiteQueue(self.path)
+        q = FILOSQLiteQueue(self.path, auto_commit=self.auto_commit)
         for i in range(1000):
             q.put('var%d' % i)
+        task_done_if_required(q)
         self.assertEqual(1000, q.qsize())
         del q
         q = FILOSQLiteQueue(self.path)
@@ -164,3 +201,9 @@ class FILOSQLite3QueueTest(unittest.TestCase):
         q.put('foobar')
         data = q.get()
         self.assertEqual('foobar', data)
+
+
+class FILOSQLite3QueueAutoCommitTest(FILOSQLite3QueueTest):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='filo_sqlqueue_auto_commit')
+        self.auto_commit = True


### PR DESCRIPTION
Performance optimization for sqlite3 based queue

Previously, each put/get is done within transaction. Since sqlite3
can only perform few dozen transaction per second, it's practical to avoid
transaction for each put/get.

In this patch, sqlite3 based queues accept the
*auto_commit=[True|False]* when initialization, when auto_commit=False is
set user need to perform *queue.task_done()* after a bulk of putting/getting
to commit all the changes made.

``auto_commit=True`` keeps the previous behavior.
