### PR TITLE
Fix in-memory queue using shared-cache

### DIFF
--- a/persistqueue/exceptions.py
+++ b/persistqueue/exceptions.py
@@ -7,3 +7,23 @@ class Empty(Exception):
 
 class Full(Exception):
     pass
+
+
+class MaxRetriesReached(Exception):
+    def __init__(self, msg, orig_ex=None, *args, **kwargs):
+        self.msg = msg
+        self.orig_ex = orig_ex
+        self.args = args
+        self.kwargs = kwargs
+
+    @property
+    def message(self):
+        msg = self.msg
+        if self.args:
+            msg = msg % self.args
+        if self.kwargs:
+            msg = msg.format(self.kwargs)
+
+        if self.orig_ex:
+            msg = msg + " Original exception: " + self.orig_ex
+        return msg

--- a/persistqueue/lib.py
+++ b/persistqueue/lib.py
@@ -1,0 +1,59 @@
+import logging
+import re
+import time as _time
+
+from persistqueue.exceptions import MaxRetriesReached
+
+log = logging.getLogger(__name__)
+
+
+def retrying(error_clz, msg=None, max=3):
+    """Retry decorator for error.
+
+    :param error_clz: exception for retry.
+    :param msg: optional exception message for retry.
+    :param max: max retry count.
+    """
+    # TODO support both @retrying and @retry() as valid syntax
+    def retry(func):
+        def wrapper(*args, **kwargs):
+            i = 0
+            while i <= max:
+                i += 1  # remember execution count
+                try:
+                    return func(*args, **kwargs)
+                except Exception as ex:
+                    retry = _retry_on_exception(ex, error_clz, msg)
+                    if retry:
+                        _raise_if_max_reached(i, max, ex)
+                        log.warning("Retrying on error '%s', left retries: "
+                                    "%d", ex, max-i)
+                        _time.sleep(i**2 * 0.1)
+                    else:
+                        raise
+        return wrapper
+    return retry
+
+
+def _raise_if_max_reached(i, max, ex):
+    if i >= max:
+        raise MaxRetriesReached('Max retries reached.', orig_ex=ex)
+
+
+def _retry_on_exception(error, error_clz, msg):
+    retry = False
+    if isinstance(error, error_clz):
+        if msg:
+            if re.search(msg, str(error)):
+                retry = True
+            else:
+                log.debug("exception '%s' occurred, "
+                          "but message did not match, "
+                          "found: '%s'", error_clz, str(error))
+                retry = False
+        else:
+            retry = True
+    else:
+        log.debug("exception '%s' occurred, but type did not match, "
+                  "found: '%s'", type(error), error_clz)
+    return retry

--- a/persistqueue/sqlqueue.py
+++ b/persistqueue/sqlqueue.py
@@ -49,12 +49,19 @@ class SQLiteQueue(sqlbase.SQLiteBase):
             row = self._select()
             # Perhaps a sqlite3 bug, sometimes (None, None) is returned
             # by select, below can avoid these invalid records.
-            if row and row[0] is not None:
-                self._delete(row[0])
-                if not self.auto_commit:
-                    # Need to commit if not automatic done by _delete
-                    sqlbase.commit_ignore_error(self._putter)
-                return row[1]  # pickled data
+            if row is not None:
+                print("_pop: ", row)
+                if row and row[0] is not None and row[0] != 0:
+                    self._delete(row[0])
+                    if not self.auto_commit:
+                        # Need to commit if not automatic done by _delete
+                        sqlbase.commit_ignore_error(self._putter)
+                    return row[1]  # pickled data
+                else:
+                    # self._delete(row[0])
+                    print ("warning: row is ", row)
+                    return None
+                    # return b'\x80\x03X\x06\x00\x00\x00var999q\x00.'
             return None
 
     def get(self, block=True, timeout=None):

--- a/tests/test_sqlqueue.py
+++ b/tests/test_sqlqueue.py
@@ -153,6 +153,7 @@ class SQLite3QueueTest(unittest.TestCase):
         def producer():
             for x in range(1000):
                 queue.put('var%d' % x)
+                print('put: var%d' % x)
                 task_done_if_required(queue)
 
         counter = []
@@ -162,7 +163,8 @@ class SQLite3QueueTest(unittest.TestCase):
 
         def consumer(index):
             for i in range(200):
-                data = queue.get(block=True)
+                data = queue.get(block=True, timeout=2)
+                print('get: index=%d, i=%d, data=%s' % (index, i, data))
                 self.assertTrue('var' in data)
                 counter[index * 200 + i] = data
 

--- a/tests/test_sqlqueue.py
+++ b/tests/test_sqlqueue.py
@@ -216,18 +216,6 @@ class SQLite3QueueInMemory(SQLite3QueueTest):
     def test_open_close_single(self):
         self.skipTest('Memory based sqlite is not persistent.')
 
-    def test_multiple_consumers(self):
-        self.skipTest('Skipped due to occasional crash during '
-                      'multithreading mode.')
-
-    def test_multi_threaded_multi_producer(self):
-        self.skipTest('Skipped due to occasional crash during '
-                      'multithreading mode.')
-
-    def test_multi_threaded_parallel(self):
-        self.skipTest('Skipped due to occasional crash during '
-                      'multithreading mode.')
-
 
 class FILOSQLite3QueueTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When share in-memory queue in multi-thread, the queue is not
properly synced between threads, this commit uses shared-cache
to achieve the synchronization.
fixes #31