### PR TITLE
[GH-45]Use the highest protocol version for pickle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   py27:
     docker:
       # Primary container image where all steps run.
-      - image: circleci/python:2.7.14
+      - image: circleci/python:2.7.15
     environment:
       - TOXENV: py27
     steps: &common_steps
@@ -39,7 +39,7 @@ jobs:
   py35:
     docker:
       # Primary container image where all steps run.
-      - image: circleci/python:3.5.4
+      - image: circleci/python:3.5.5
     environment:
       - TOXENV: py35
 
@@ -48,7 +48,7 @@ jobs:
   py36:
     docker:
       # Primary container image where all steps run.
-      - image: circleci/python:3.6.4
+      - image: circleci/python:3.6.5
     environment:
       - TOXENV: py36
     steps: *common_steps
@@ -56,7 +56,7 @@ jobs:
   py37:
     docker:
       # Primary container image where all steps run.
-      - image: circleci/python:3.7.0a4
+      - image: circleci/python:3.7.0b4
     environment:
       - TOXENV: py37
     steps: *common_steps

--- a/README.rst
+++ b/README.rst
@@ -262,30 +262,26 @@ Performance impact
   needs to perform ``queue.task_done()`` to persist the changes made to the disk since
   last ``task_done`` invocation.
 
+- **pickle protocol selection**
+
+  From v0.3.6, the `persistqueue` will select `Protocol version 2` for python2 and `Protocol version 4` for python3
+  respectively. This selection only happens when the directory is not present when initializing the queue.
+
 Tests
 -----
 
 *persist-queue* use ``tox`` to trigger tests.
 
-to trigger tests based on python2.7/python3.x, use:
+- Unit test
 
 .. code-block:: console
 
-    tox -e py27
+    tox -e <PYTHON_VERSION>
 
-.. code-block:: console
+Available `<PYTHON_VERSION>`: `py27`, `py34`, `py35`, `py36`, `py37`
 
-    tox -e py34
 
-.. code-block:: console
-
-    tox -e py35
-
-.. code-block:: console
-
-    tox -e py36
-
-to trigger pep8 check, use:
+- PEP8 check
 
 .. code-block:: console
 

--- a/persistqueue/__init__.py
+++ b/persistqueue/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 __author__ = 'Peter Wang'
-__license__ = 'BSD License'
+__license__ = 'BSD'
 __version__ = '0.3.5'
 
 from .exceptions import Empty, Full  # noqa

--- a/persistqueue/common.py
+++ b/persistqueue/common.py
@@ -1,0 +1,15 @@
+#! coding = utf-8
+
+import logging
+import pickle
+
+log = logging.getLogger(__name__)
+
+
+def select_pickle_protocol():
+    if pickle.HIGHEST_PROTOCOL <= 2:
+        r = 2  # python2 use fixed 2
+    else:
+        r = 4  # python3 use fixed 4
+    log.info("Selected pickle protocol: '{}'".format(r))
+    return r

--- a/persistqueue/pdict.py
+++ b/persistqueue/pdict.py
@@ -1,3 +1,4 @@
+#! coding = utf-8
 import logging
 import pickle
 import sqlite3

--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -10,6 +10,8 @@ import tempfile
 import threading
 from time import time as _time
 from persistqueue.exceptions import Empty, Full
+from persistqueue import common
+
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +40,7 @@ class Queue(object):
         self.chunksize = chunksize
         self.tempdir = tempdir
         self.maxsize = maxsize
+        self.protocol = None
         self._init(maxsize)
         if self.tempdir:
             if os.stat(self.path).st_dev != os.stat(self.tempdir).st_dev:
@@ -69,6 +72,7 @@ class Queue(object):
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)
+            self.protocol = common.select_pickle_protocol()
 
     def join(self):
         with self.all_tasks_done:

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -3,6 +3,8 @@ import os
 import sqlite3
 import threading
 
+from persistqueue import common
+
 sqlite3.enable_callback_tracebacks(True)
 
 log = logging.getLogger(__name__)
@@ -70,7 +72,7 @@ class SQLiteBase(object):
         self.timeout = timeout
         self.multithreading = multithreading
         self.auto_commit = auto_commit
-
+        self.protocol = None
         self._init()
 
     def _init(self):
@@ -79,10 +81,13 @@ class SQLiteBase(object):
         if self.path == self._MEMORY:
             self.memory_sql = True
             log.debug("Initializing Sqlite3 Queue in memory.")
+            self.protocol = common.select_pickle_protocol()
         elif not os.path.exists(self.path):
             os.makedirs(self.path)
             log.debug(
                 'Initializing Sqlite3 Queue with path {}'.format(self.path))
+            # Set to current highest pickle protocol for new queue.
+            self.protocol = common.select_pickle_protocol()
 
         self._conn = self._new_db_connection(
             self.path, self.multithreading, self.timeout)
@@ -96,11 +101,10 @@ class SQLiteBase(object):
             if not self.memory_sql:
                 self._putter = self._new_db_connection(
                     self.path, self.multithreading, self.timeout)
-        # if self.auto_commit is False:
-        #     log.warning('auto_commit=False is still experimental,'
-        #                 'only use it with care.')
-        #     self._getter.isolation_level = "DEFERRED"
-        #     self._putter.isolation_level = "DEFERRED"
+        if self.protocol is not None:
+            self._conn.text_factory = str
+            self._putter.text_factory = str
+
         # SQLite3 transaction lock
         self.tran_lock = threading.Lock()
         self.put_event = threading.Event()

--- a/persistqueue/sqlqueue.py
+++ b/persistqueue/sqlqueue.py
@@ -37,7 +37,7 @@ class SQLiteQueue(sqlbase.SQLiteBase):
                         ' {column} {op} ? ORDER BY {key_column} ASC LIMIT 1 '
 
     def put(self, item):
-        obj = pickle.dumps(item)
+        obj = pickle.dumps(item, protocol=self.protocol)
         self._insert_into(obj, _time.time())
         self.total += 1
         self.put_event.set()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='wangxu198709@gmail.com',
     maintainer='Peter Wang',
     maintainer_email='wangxu198709@gmail.com',
-    license='BSD License',
+    license='BSD',
     packages=find_packages(),
     platforms=["all"],
     url='http://github.com/peter-wangxu/persist-queue',

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import random
 import shutil
+import sys
 import tempfile
 import unittest
 from threading import Thread
@@ -249,3 +250,13 @@ class PersistTest(unittest.TestCase):
 
         self.assertTrue(b'a', q.get())
         self.assertTrue(b'b', q.get())
+
+    def test_protocol_1(self):
+        shutil.rmtree(self.path)
+
+        q = Queue(path=self.path)
+        self.assertEqual(q.protocol, 2 if sys.version_info[0] == 2 else 4)
+
+    def test_protocol_2(self):
+        q = Queue(path=self.path)
+        self.assertEqual(q.protocol, None)

--- a/tests/test_sqlqueue.py
+++ b/tests/test_sqlqueue.py
@@ -2,6 +2,7 @@
 
 import random
 import shutil
+import sys
 import tempfile
 import unittest
 from threading import Thread
@@ -194,6 +195,15 @@ class SQLite3QueueTest(unittest.TestCase):
         self.assertEqual(3, q.get())
         self.assertEqual(7, q.qsize())
 
+    def test_protocol_1(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+        q = SQLiteQueue(path=self.path)
+        self.assertEqual(q.protocol, 2 if sys.version_info[0] == 2 else 4)
+
+    def test_protocol_2(self):
+        q = SQLiteQueue(path=self.path)
+        self.assertEqual(q.protocol, None)
+
 
 class SQLite3QueueNoAutoCommitTest(SQLite3QueueTest):
     def setUp(self):
@@ -241,6 +251,9 @@ class SQLite3QueueInMemory(SQLite3QueueTest):
 
     def test_task_done_with_restart(self):
         self.skipTest('Skipped due to not persistent.')
+
+    def test_protocol_2(self):
+        self.skipTest('In memory queue is always new.')
 
 
 class FILOSQLite3QueueTest(unittest.TestCase):


### PR DESCRIPTION
By default pickle uses protocol version 0, which is ASCII and not so
efficient (at least in terms of space).

This commit will choose highest protocol available in PythonX.