### PR TITLE
add ack support

### DIFF
--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -1,0 +1,206 @@
+# coding=utf-8
+import logging
+import pickle
+import sqlite3
+import time as _time
+import threading
+import warnings
+
+from persistqueue import sqlbase
+from persistqueue.exceptions import Empty
+
+sqlite3.enable_callback_tracebacks(True)
+
+log = logging.getLogger(__name__)
+
+# 10 seconds internal for `wait` of event
+TICK_FOR_WAIT = 10
+
+
+class SQLiteAckQueue(sqlbase.SQLiteBase):
+    """SQLite3 based FIFO queue."""
+
+    _TABLE_NAME = 'queue'
+    _KEY_COLUMN = '_id'  # the name of the key column, used in DB CRUD
+    _ACK_STATUS_INITED = "0"  # init status
+    _ACK_STATUS_READY = "1"  # dispatched and nacked status
+    _ACK_STATUS_UNACK = "2"  # get by consumer but not acked
+    _ACK_STATUS_ACKED = "5"  # acked by consumer. rows acked could be cleared due to size limit.
+    _ACK_STATUS_ACKFAILED = "9"  # there was something wrong during consumer process item
+    _MAX_ACKED_LENGTH = 1000
+    # SQL to create a table
+    _SQL_CREATE = ('CREATE TABLE IF NOT EXISTS {table_name} ('
+                   '{key_column} INTEGER PRIMARY KEY AUTOINCREMENT, '
+                   'data BLOB, timestamp FLOAT, status INTEGER)')
+    # SQL to insert a record
+    _SQL_INSERT = 'INSERT INTO {table_name} (data, timestamp, status) VALUES (?, ?, %s)' % _ACK_STATUS_INITED
+    # SQL to select a record
+    _SQL_SELECT = ('SELECT {key_column}, data, status FROM {table_name} '
+                   'WHERE status < %s '
+                   'ORDER BY {key_column} ASC LIMIT 1'  % _ACK_STATUS_UNACK)
+    _SQL_MARK_ACK_UPDATE = 'UPDATE {table_name} SET status = ? WHERE {key_column} = ?'
+    _SQL_SELECT_WHERE = 'SELECT {key_column}, data FROM {table_name} WHERE status < %s AND' \
+                        ' {column} {op} ? ORDER BY {key_column} ASC LIMIT 1 '  % _ACK_STATUS_UNACK
+
+    def __init__(self, *args, **kwargs):
+        super(SQLiteAckQueue, self).__init__(*args, **kwargs)
+        if not self.auto_commit:
+            warnings.warn("disable auto commit is not support in ack queue")
+            self.auto_commit = True
+        self._unack_cache = {}
+
+    def put(self, item):
+        obj = pickle.dumps(item, protocol=self.protocol)
+        self._insert_into(obj, _time.time())
+        self.total += 1
+        self.put_event.set()
+
+    def _init(self):
+        super(SQLiteAckQueue, self)._init()
+        # Action lock to assure multiple action to be *atomic*
+        self.action_lock = threading.Lock()
+        if not self.auto_commit:
+            # Refresh current cursor after restart
+            head = self._select()
+            if head:
+                self.cursor = head[0] - 1
+            else:
+                self.cursor = 0
+        self.total = self._count()
+
+    def _count(self):
+        sql = 'SELECT COUNT({}) FROM {} WHERE status < ?'.format(self._key_column,
+                                                self._table_name)
+        row = self._getter.execute(sql, (self._ACK_STATUS_UNACK)).fetchone()
+        return row[0] if row else 0
+
+    @sqlbase.with_conditional_transaction
+    def _mark_ack_status(self, key, status):
+        return self._sql_mark_ack_status, (status, key, )
+
+    @sqlbase.with_conditional_transaction
+    def clear_acked_data(self):
+        return "DELETE FROM {table_name} WHERE {key_column} IN (SELECT _id FROM {table_name} WHERE status = ? ORDER BY {key_column} DESC LIMIT 1000 OFFSET {max_acked_length})".format(table_name=self._table_name, key_column=self._key_column, max_acked_length=self._MAX_ACKED_LENGTH), self._ACK_STATUS_ACKED
+
+    @property
+    def _sql_mark_ack_status(self):
+        return self._SQL_MARK_ACK_UPDATE.format(table_name=self._table_name, key_column=self._key_column)
+
+    def _pop(self):
+        with self.action_lock:
+            row = self._select()
+            # Perhaps a sqlite3 bug, sometimes (None, None) is returned
+            # by select, below can avoid these invalid records.
+            if row and row[0] is not None:
+                self._mark_ack_status(row[0], self._ACK_STATUS_UNACK)
+                pickled_data = row[1]  # pickled data
+                item = pickle.loads(pickled_data)
+                self._unack_cache[row[0]] = item
+                self.total -= 1
+                return item
+            return None
+
+    def _find_item_id(self, item):
+        for key, value in self._unack_cache.items():
+            if value is item:
+                return key
+        log.warning("Can't find item %s from unack cache", item)
+        return None
+
+    def ack(self, item):
+        with self.action_lock:
+            _id = self._find_item_id(item)
+            if _id is None:
+                return
+            self._mark_ack_status(_id, self._ACK_STATUS_ACKED)
+            self._unack_cache.pop(_id)
+
+    def ack_failed(self, item):
+        with self.action_lock:
+            _id = self._find_item_id(item)
+            if _id is None:
+                return
+            self._mark_ack_status(_id, self._ACK_STATUS_ACKFAILED)
+            self._unack_cache.pop(_id)
+
+    def nack(self, item):
+        with self.action_lock:
+            _id = self._find_item_id(item)
+            if _id is None:
+                return
+            self._mark_ack_status(_id, self._ACK_STATUS_READY)
+            self._unack_cache.pop(_id)
+
+    def get(self, block=True, timeout=None):
+        if not block:
+            pickled = self._pop()
+            if not pickled:
+                raise Empty
+        elif timeout is None:
+            # block until a put event.
+            pickled = self._pop()
+            while not pickled:
+                self.put_event.clear()
+                self.put_event.wait(TICK_FOR_WAIT)
+                pickled = self._pop()
+        elif timeout < 0:
+            raise ValueError("'timeout' must be a non-negative number")
+        else:
+            # block until the timeout reached
+            endtime = _time.time() + timeout
+            pickled = self._pop()
+            while not pickled:
+                self.put_event.clear()
+                remaining = endtime - _time.time()
+                if remaining <= 0.0:
+                    raise Empty
+                self.put_event.wait(
+                    TICK_FOR_WAIT if TICK_FOR_WAIT < remaining else remaining)
+                pickled = self._pop()
+        item = pickled
+        return item
+
+    def task_done(self):
+        """Persist the current state if auto_commit=False."""
+        if not self.auto_commit:
+            self._task_done()
+
+    @property
+    def size(self):
+        return self.total
+
+    def qsize(self):
+        return self.size
+
+    def __len__(self):
+        return self.size
+
+
+FIFOSQLiteQueue = SQLiteAckQueue
+
+
+class FILOSQLiteAckQueue(SQLiteAckQueue):
+    """SQLite3 based FILO queue."""
+
+    _TABLE_NAME = 'filo_queue'
+    # SQL to select a record
+    _SQL_SELECT = ('SELECT {key_column}, data FROM {table_name} '
+                   'WHERE status < %s '
+                   'ORDER BY {key_column} DESC LIMIT 1'  % SQLiteAckQueue._ACK_STATUS_UNACK)
+
+
+class UniqueAckQ(SQLiteAckQueue):
+    _TABLE_NAME = 'unique_queue'
+    _SQL_CREATE = ('CREATE TABLE IF NOT EXISTS {table_name} ('
+                   '{key_column} INTEGER PRIMARY KEY AUTOINCREMENT, '
+                   'data BLOB, timestamp FLOAT, status INTEGER, UNIQUE (data))')
+
+    def put(self, item):
+        obj = pickle.dumps(item)
+        try:
+            self._insert_into(obj, _time.time())
+        except sqlite3.IntegrityError:
+            pass
+        else:
+            self.total += 1
+            self.put_event.set()

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -17,30 +17,33 @@ log = logging.getLogger(__name__)
 TICK_FOR_WAIT = 10
 
 
+class ACK_STATUS:
+    inited = '0'
+    ready = '1'
+    unack = '2'
+    acked = '5'
+    ack_failed = '9'
+
+
 class SQLiteAckQueue(sqlbase.SQLiteBase):
     """SQLite3 based FIFO queue."""
 
-    _TABLE_NAME = 'queue'
+    _TABLE_NAME = 'ack_queue'
     _KEY_COLUMN = '_id'  # the name of the key column, used in DB CRUD
-    _ACK_STATUS_INITED = "0"  # init status
-    _ACK_STATUS_READY = "1"  # dispatched and nacked status
-    _ACK_STATUS_UNACK = "2"  # get by consumer but not acked
-    _ACK_STATUS_ACKED = "5"  # acked by consumer. rows acked could be cleared due to size limit.
-    _ACK_STATUS_ACKFAILED = "9"  # there was something wrong during consumer process item
     _MAX_ACKED_LENGTH = 1000
     # SQL to create a table
     _SQL_CREATE = ('CREATE TABLE IF NOT EXISTS {table_name} ('
                    '{key_column} INTEGER PRIMARY KEY AUTOINCREMENT, '
                    'data BLOB, timestamp FLOAT, status INTEGER)')
     # SQL to insert a record
-    _SQL_INSERT = 'INSERT INTO {table_name} (data, timestamp, status) VALUES (?, ?, %s)' % _ACK_STATUS_INITED
+    _SQL_INSERT = 'INSERT INTO {table_name} (data, timestamp, status) VALUES (?, ?, %s)' % ACK_STATUS.inited
     # SQL to select a record
     _SQL_SELECT = ('SELECT {key_column}, data, status FROM {table_name} '
                    'WHERE status < %s '
-                   'ORDER BY {key_column} ASC LIMIT 1'  % _ACK_STATUS_UNACK)
+                   'ORDER BY {key_column} ASC LIMIT 1' % ACK_STATUS.unack)
     _SQL_MARK_ACK_UPDATE = 'UPDATE {table_name} SET status = ? WHERE {key_column} = ?'
     _SQL_SELECT_WHERE = 'SELECT {key_column}, data FROM {table_name} WHERE status < %s AND' \
-                        ' {column} {op} ? ORDER BY {key_column} ASC LIMIT 1 '  % _ACK_STATUS_UNACK
+                        ' {column} {op} ? ORDER BY {key_column} ASC LIMIT 1 ' % ACK_STATUS.unack
 
     def __init__(self, *args, **kwargs):
         super(SQLiteAckQueue, self).__init__(*args, **kwargs)
@@ -59,20 +62,31 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
         super(SQLiteAckQueue, self)._init()
         # Action lock to assure multiple action to be *atomic*
         self.action_lock = threading.Lock()
-        if not self.auto_commit:
-            # Refresh current cursor after restart
-            head = self._select()
-            if head:
-                self.cursor = head[0] - 1
-            else:
-                self.cursor = 0
         self.total = self._count()
 
     def _count(self):
         sql = 'SELECT COUNT({}) FROM {} WHERE status < ?'.format(self._key_column,
-                                                self._table_name)
-        row = self._getter.execute(sql, (self._ACK_STATUS_UNACK)).fetchone()
+                                                                 self._table_name)
+        row = self._getter.execute(sql, (ACK_STATUS.unack, )).fetchone()
         return row[0] if row else 0
+
+    def _ack_count_via_status(self, status):
+        sql = 'SELECT COUNT({}) FROM {} WHERE status = ?'.format(self._key_column,
+                                                                 self._table_name)
+        row = self._getter.execute(sql, (status, )).fetchone()
+        return row[0] if row else 0
+
+    def unack_count(self):
+        return self._ack_count_via_status(ACK_STATUS.unack)
+
+    def acked_count(self):
+        return self._ack_count_via_status(ACK_STATUS.acked)
+
+    def ready_count(self):
+        return self._ack_count_via_status(ACK_STATUS.ready)
+
+    def ack_failed_count(self):
+        return self._ack_count_via_status(ACK_STATUS.ack_failed)
 
     @sqlbase.with_conditional_transaction
     def _mark_ack_status(self, key, status):
@@ -80,7 +94,15 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
 
     @sqlbase.with_conditional_transaction
     def clear_acked_data(self):
-        return "DELETE FROM {table_name} WHERE {key_column} IN (SELECT _id FROM {table_name} WHERE status = ? ORDER BY {key_column} DESC LIMIT 1000 OFFSET {max_acked_length})".format(table_name=self._table_name, key_column=self._key_column, max_acked_length=self._MAX_ACKED_LENGTH), self._ACK_STATUS_ACKED
+        sql = """DELETE FROM {table_name}
+            WHERE {key_column} IN (
+                SELECT _id FROM {table_name} WHERE status = ? 
+                ORDER BY {key_column} DESC 
+                LIMIT 1000 OFFSET {max_acked_length}
+            )""".format(table_name=self._table_name,
+                        key_column=self._key_column,
+                        max_acked_length=self._MAX_ACKED_LENGTH)
+        return sql, ACK_STATUS.acked
 
     @property
     def _sql_mark_ack_status(self):
@@ -92,7 +114,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             # Perhaps a sqlite3 bug, sometimes (None, None) is returned
             # by select, below can avoid these invalid records.
             if row and row[0] is not None:
-                self._mark_ack_status(row[0], self._ACK_STATUS_UNACK)
+                self._mark_ack_status(row[0], ACK_STATUS.unack)
                 pickled_data = row[1]  # pickled data
                 item = pickle.loads(pickled_data)
                 self._unack_cache[row[0]] = item
@@ -112,7 +134,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             _id = self._find_item_id(item)
             if _id is None:
                 return
-            self._mark_ack_status(_id, self._ACK_STATUS_ACKED)
+            self._mark_ack_status(_id, ACK_STATUS.acked)
             self._unack_cache.pop(_id)
 
     def ack_failed(self, item):
@@ -120,7 +142,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             _id = self._find_item_id(item)
             if _id is None:
                 return
-            self._mark_ack_status(_id, self._ACK_STATUS_ACKFAILED)
+            self._mark_ack_status(_id, ACK_STATUS.ack_failed)
             self._unack_cache.pop(_id)
 
     def nack(self, item):
@@ -128,8 +150,9 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             _id = self._find_item_id(item)
             if _id is None:
                 return
-            self._mark_ack_status(_id, self._ACK_STATUS_READY)
+            self._mark_ack_status(_id, ACK_STATUS.ready)
             self._unack_cache.pop(_id)
+            self.total += 1
 
     def get(self, block=True, timeout=None):
         if not block:
@@ -176,21 +199,21 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
         return self.size
 
 
-FIFOSQLiteQueue = SQLiteAckQueue
+FIFOSQLiteAckQueue = SQLiteAckQueue
 
 
 class FILOSQLiteAckQueue(SQLiteAckQueue):
-    """SQLite3 based FILO queue."""
+    """SQLite3 based FILO queue with ack support."""
 
-    _TABLE_NAME = 'filo_queue'
+    _TABLE_NAME = 'ack_filo_queue'
     # SQL to select a record
     _SQL_SELECT = ('SELECT {key_column}, data FROM {table_name} '
                    'WHERE status < %s '
-                   'ORDER BY {key_column} DESC LIMIT 1'  % SQLiteAckQueue._ACK_STATUS_UNACK)
+                   'ORDER BY {key_column} DESC LIMIT 1' % ACK_STATUS.unack)
 
 
 class UniqueAckQ(SQLiteAckQueue):
-    _TABLE_NAME = 'unique_queue'
+    _TABLE_NAME = 'ack_unique_queue'
     _SQL_CREATE = ('CREATE TABLE IF NOT EXISTS {table_name} ('
                    '{key_column} INTEGER PRIMARY KEY AUTOINCREMENT, '
                    'data BLOB, timestamp FLOAT, status INTEGER, UNIQUE (data))')

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -26,7 +26,7 @@ class ACK_STATUS:
 
 
 class SQLiteAckQueue(sqlbase.SQLiteBase):
-    """SQLite3 based FIFO queue."""
+    """SQLite3 based FIFO queue with ack support."""
 
     _TABLE_NAME = 'ack_queue'
     _KEY_COLUMN = '_id'  # the name of the key column, used in DB CRUD

--- a/tests/test_sqlackqueue.py
+++ b/tests/test_sqlackqueue.py
@@ -7,7 +7,10 @@ import tempfile
 import unittest
 from threading import Thread
 
-from persistqueue.sqlackqueue import SQLiteAckQueue, FILOSQLiteAckQueue, UniqueAckQ
+from persistqueue.sqlackqueue import (
+    SQLiteAckQueue,
+    FILOSQLiteAckQueue,
+    UniqueAckQ)
 from persistqueue import Empty
 
 
@@ -82,8 +85,10 @@ class SQLite3AckQueueTest(unittest.TestCase):
 
         # self.skipTest("Not supported multi-thread.")
 
-        m_queue = SQLiteAckQueue(path=self.path, multithreading=True,
-                              auto_commit=self.auto_commit)
+        m_queue = SQLiteAckQueue(
+            path=self.path, multithreading=True,
+            auto_commit=self.auto_commit
+        )
 
         def producer():
             for i in range(1000):
@@ -106,8 +111,10 @@ class SQLite3AckQueueTest(unittest.TestCase):
 
     def test_multi_threaded_multi_producer(self):
         """Test sqlqueue can be used by multiple producers."""
-        queue = SQLiteAckQueue(path=self.path, multithreading=True,
-                            auto_commit=self.auto_commit)
+        queue = SQLiteAckQueue(
+            path=self.path, multithreading=True,
+            auto_commit=self.auto_commit
+        )
 
         def producer(seq):
             for i in range(10):
@@ -134,8 +141,10 @@ class SQLite3AckQueueTest(unittest.TestCase):
     def test_multiple_consumers(self):
         """Test sqlqueue can be used by multiple consumers."""
 
-        queue = SQLiteAckQueue(path=self.path, multithreading=True,
-                            auto_commit=self.auto_commit)
+        queue = SQLiteAckQueue(
+            path=self.path, multithreading=True,
+            auto_commit=self.auto_commit
+        )
 
         def producer():
             for x in range(1000):

--- a/tests/test_sqlackqueue.py
+++ b/tests/test_sqlackqueue.py
@@ -1,0 +1,314 @@
+# coding=utf-8
+
+import random
+import shutil
+import sys
+import tempfile
+import unittest
+from threading import Thread
+
+from persistqueue.sqlackqueue import SQLiteAckQueue, FILOSQLiteAckQueue, UniqueAckQ
+from persistqueue import Empty
+
+
+class SQLite3QueueTest(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='sqlqueue')
+        self.auto_commit = True
+
+    def tearDown(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+
+    def test_raise_empty(self):
+        q = SQLiteAckQueue(self.path, auto_commit=self.auto_commit)
+
+        q.put('first')
+        d = q.get()
+        self.assertEqual('first', d)
+        self.assertRaises(Empty, q.get, block=False)
+
+        # assert with timeout
+        self.assertRaises(Empty, q.get, block=True, timeout=1.0)
+        # assert with negative timeout
+        self.assertRaises(ValueError, q.get, block=True, timeout=-1.0)
+
+    def test_open_close_single(self):
+        """Write 1 item, close, reopen checking if same item is there"""
+
+        q = SQLiteAckQueue(self.path, auto_commit=self.auto_commit)
+        q.put(b'var1')
+        del q
+        q = SQLiteAckQueue(self.path)
+        self.assertEqual(1, q.qsize())
+        self.assertEqual(b'var1', q.get())
+
+    def test_open_close_1000(self):
+        """Write 1000 items, close, reopen checking if all items are there"""
+
+        q = SQLiteAckQueue(self.path, auto_commit=self.auto_commit)
+        for i in range(1000):
+            q.put('var%d' % i)
+
+        self.assertEqual(1000, q.qsize())
+        del q
+        q = SQLiteAckQueue(self.path)
+        self.assertEqual(1000, q.qsize())
+        for i in range(1000):
+            data = q.get()
+            self.assertEqual('var%d' % i, data)
+        # assert adding another one still works
+        q.put('foobar')
+        data = q.get()
+        self.assertEqual('foobar', data)
+
+    def test_random_read_write(self):
+        """Test random read/write"""
+
+        q = SQLiteAckQueue(self.path, auto_commit=self.auto_commit)
+        n = 0
+        for _ in range(1000):
+            if random.random() < 0.5:
+                if n > 0:
+                    q.get()
+                    n -= 1
+                else:
+                    self.assertRaises(Empty, q.get, block=False)
+            else:
+                q.put('var%d' % random.getrandbits(16))
+                n += 1
+
+    def test_multi_threaded_parallel(self):
+        """Create consumer and producer threads, check parallelism"""
+
+        # self.skipTest("Not supported multi-thread.")
+
+        m_queue = SQLiteAckQueue(path=self.path, multithreading=True,
+                              auto_commit=self.auto_commit)
+
+        def producer():
+            for i in range(1000):
+                m_queue.put('var%d' % i)
+
+        def consumer():
+            for i in range(1000):
+                x = m_queue.get(block=True)
+                self.assertEqual('var%d' % i, x)
+
+        c = Thread(target=consumer)
+        c.start()
+        p = Thread(target=producer)
+        p.start()
+        p.join()
+        c.join()
+        self.assertEqual(0, m_queue.size)
+        self.assertEqual(0, len(m_queue))
+        self.assertRaises(Empty, m_queue.get, block=False)
+
+    def test_multi_threaded_multi_producer(self):
+        """Test sqlqueue can be used by multiple producers."""
+        queue = SQLiteAckQueue(path=self.path, multithreading=True,
+                            auto_commit=self.auto_commit)
+
+        def producer(seq):
+            for i in range(10):
+                queue.put('var%d' % (i + (seq * 10)))
+
+        def consumer():
+            for _ in range(100):
+                data = queue.get(block=True)
+                self.assertTrue('var' in data)
+
+        c = Thread(target=consumer)
+        c.start()
+        producers = []
+        for seq in range(10):
+            t = Thread(target=producer, args=(seq,))
+            t.start()
+            producers.append(t)
+
+        for t in producers:
+            t.join()
+
+        c.join()
+
+    def test_multiple_consumers(self):
+        """Test sqlqueue can be used by multiple consumers."""
+
+        queue = SQLiteAckQueue(path=self.path, multithreading=True,
+                            auto_commit=self.auto_commit)
+
+        def producer():
+            for x in range(1000):
+                queue.put('var%d' % x)
+
+        counter = []
+        # Set all to 0
+        for _ in range(1000):
+            counter.append(0)
+
+        def consumer(index):
+            for i in range(200):
+                data = queue.get(block=True)
+                self.assertTrue('var' in data)
+                counter[index * 200 + i] = data
+
+        p = Thread(target=producer)
+        p.start()
+        consumers = []
+        for index in range(5):
+            t = Thread(target=consumer, args=(index,))
+            t.start()
+            consumers.append(t)
+
+        p.join()
+        for t in consumers:
+            t.join()
+
+        self.assertEqual(0, queue.qsize())
+        for x in range(1000):
+            self.assertNotEqual(0, counter[x],
+                                "not 0 for counter's index %s" % x)
+
+    def test_task_done_with_restart(self):
+        """Test that items are not deleted before task_done."""
+
+        q = SQLiteAckQueue(path=self.path,
+                           # auto_commit=False
+                           )
+
+        for i in range(1, 11):
+            q.put(i)
+
+        self.assertEqual(1, q.get())
+        self.assertEqual(2, q.get())
+        # size is correct before task_done
+        self.assertEqual(8, q.qsize())
+        q.task_done()
+        # make sure the size still correct
+        self.assertEqual(8, q.qsize())
+
+        self.assertEqual(3, q.get())
+        # without task done
+        del q
+#         q = SQLiteAckQueue(path=self.path,
+#                            # auto_commit=False
+#                            )
+#         # After restart, the qsize and head item are the same
+#         self.assertEqual(8, q.qsize())
+#         # After restart, the queue still works
+#         self.assertEqual(3, q.get())
+#         self.assertEqual(7, q.qsize())
+
+    def test_protocol_1(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+        q = SQLiteAckQueue(path=self.path)
+        self.assertEqual(q.protocol, 2 if sys.version_info[0] == 2 else 4)
+
+    def test_protocol_2(self):
+        q = SQLiteAckQueue(path=self.path)
+        self.assertEqual(q.protocol, None)
+
+
+class SQLite3QueueNoAutoCommitTest(SQLite3QueueTest):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='sqlqueue_auto_commit')
+        self.auto_commit = False
+
+    def test_multiple_consumers(self):
+        """
+        FAIL: test_multiple_consumers (
+        -tests.test_sqlqueue.SQLite3QueueNoAutoCommitTest)
+        Test sqlqueue can be used by multiple consumers.
+        ----------------------------------------------------------------------
+        Traceback (most recent call last):
+        File "persist-queue\tests\test_sqlqueue.py", line 183,
+        -in test_multiple_consumers
+        self.assertEqual(0, queue.qsize())
+        AssertionError: 0 != 72
+        :return:
+        """
+        self.skipTest('Skipped due to a known bug above.')
+
+
+class SQLite3QueueInMemory(SQLite3QueueTest):
+    def setUp(self):
+        self.path = ":memory:"
+        self.auto_commit = True
+
+    def test_open_close_1000(self):
+        self.skipTest('Memory based sqlite is not persistent.')
+
+    def test_open_close_single(self):
+        self.skipTest('Memory based sqlite is not persistent.')
+
+    def test_multiple_consumers(self):
+        self.skipTest('Skipped due to occasional crash during '
+                      'multithreading mode.')
+
+    def test_multi_threaded_multi_producer(self):
+        self.skipTest('Skipped due to occasional crash during '
+                      'multithreading mode.')
+
+    def test_multi_threaded_parallel(self):
+        self.skipTest('Skipped due to occasional crash during '
+                      'multithreading mode.')
+
+    def test_task_done_with_restart(self):
+        self.skipTest('Skipped due to not persistent.')
+
+    def test_protocol_2(self):
+        self.skipTest('In memory queue is always new.')
+
+
+class FILOSQLite3QueueTest(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='filo_sqlqueue')
+        self.auto_commit = True
+
+    def tearDown(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+
+    def test_open_close_1000(self):
+        """Write 1000 items, close, reopen checking if all items are there"""
+
+        q = FILOSQLiteAckQueue(self.path, auto_commit=self.auto_commit)
+        for i in range(1000):
+            q.put('var%d' % i)
+        self.assertEqual(1000, q.qsize())
+        del q
+        q = FILOSQLiteAckQueue(self.path)
+        self.assertEqual(1000, q.qsize())
+        for i in range(1000):
+            data = q.get()
+            self.assertEqual('var%d' % (999 - i), data)
+        # assert adding another one still works
+        q.put('foobar')
+        data = q.get()
+        self.assertEqual('foobar', data)
+
+
+class FILOSQLite3QueueNoAutoCommitTest(FILOSQLite3QueueTest):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='filo_sqlqueue_auto_commit')
+        self.auto_commit = False
+
+
+class SQLite3UniqueAckQueueTest(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(suffix='sqlqueue')
+        self.auto_commit = True
+
+    def test_add_duplicate_item(self):
+        q = UniqueAckQ(self.path)
+        q.put(1111)
+        self.assertEqual(1, q.size)
+        # put duplicate item
+        q.put(1111)
+        self.assertEqual(1, q.size)
+
+        q.put(2222)
+        self.assertEqual(2, q.size)
+
+        del q
+        q = UniqueAckQ(self.path)
+        self.assertEqual(2, q.size)


### PR DESCRIPTION
A simple and light queue support "ack" based on sqlite queue.

The core functions:
get: get from queue and mark item as unack
ack: mark item as acked
nack: there might be something wrong with current cusumer, so mark item as ready and new consumer will get it
ack_failed: there might be something wrong during process, so just mark item as failed.