### PR TITLE
Allow configuring serializer in file based queue

### DIFF
--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -4,13 +4,13 @@
 
 import logging
 import os
-import pickle
 import tempfile
 
 import threading
 from time import time as _time
+
+import persistqueue.serializers.pickle
 from persistqueue.exceptions import Empty, Full
-from persistqueue import common
 
 
 log = logging.getLogger(__name__)
@@ -56,7 +56,8 @@ def atomic_rename(src, dst):
 
 
 class Queue(object):
-    def __init__(self, path, maxsize=0, chunksize=100, tempdir=None):
+    def __init__(self, path, maxsize=0, chunksize=100, tempdir=None,
+                 serializer=persistqueue.serializers.pickle):
         """Create a persistent queue object on a given path.
 
         The argument path indicates a directory where enqueued data should be
@@ -68,13 +69,20 @@ class Queue(object):
         The tempdir parameter indicates where temporary files should be stored.
         The tempdir has to be located on the same disk as the enqueued data in
         order to obtain atomic operations.
+
+        The serializer parameter controls how enqueued data is serialized. It
+        must have methods dump(value, fp) and load(fp). The dump method must
+        serialize value and write it to fp, and may be called for multiple
+        values with the same fp. The load method must deserialize and return
+        one value from fp, and may be called multiple times with the same fp
+        to read multiple values.
         """
         log.debug('Initializing File based Queue with path {}'.format(path))
         self.path = path
         self.chunksize = chunksize
         self.tempdir = tempdir
         self.maxsize = maxsize
-        self.protocol = None
+        self.serializer = serializer
         self._init(maxsize)
         if self.tempdir:
             if os.stat(self.path).st_dev != os.stat(self.tempdir).st_dev:
@@ -106,7 +114,6 @@ class Queue(object):
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)
-            self.protocol = common.select_pickle_protocol()
 
     def join(self):
         with self.all_tasks_done:
@@ -149,7 +156,7 @@ class Queue(object):
             self.not_full.release()
 
     def _put(self, item):
-        pickle.dump(item, self.headf)
+        self.serializer.dump(item, self.headf)
         self.headf.flush()
         hnum, hpos, _ = self.info['head']
         hpos += 1
@@ -197,7 +204,7 @@ class Queue(object):
         hnum, hcnt, _ = self.info['head']
         if [tnum, tcnt] >= [hnum, hcnt]:
             return None
-        data = pickle.load(self.tailf)
+        data = self.serializer.load(self.tailf)
         toffset = self.tailf.tell()
         tcnt += 1
         if tcnt == self.info['chunksize'] and tnum <= hnum:
@@ -232,7 +239,7 @@ class Queue(object):
         infopath = self._infopath()
         if os.path.exists(infopath):
             with open(infopath, 'rb') as f:
-                info = pickle.load(f)
+                info = self.serializer.load(f)
         else:
             info = {
                 'chunksize': self.chunksize,
@@ -250,8 +257,8 @@ class Queue(object):
 
     def _saveinfo(self):
         tmpfd, tmpfn = self._gettempfile()
-        os.write(tmpfd, pickle.dumps(self.info))
-        os.close(tmpfd)
+        with os.fdopen(tmpfd, "wb") as tmpfo:
+            self.serializer.dump(self.info, tmpfo)
         atomic_rename(tmpfn, self._infopath())
         self._clear_tail_file()
 

--- a/persistqueue/serializers/json.py
+++ b/persistqueue/serializers/json.py
@@ -1,0 +1,30 @@
+#! coding = utf-8
+
+"""
+A serializer that extends json to use bytes and uses newlines to store
+multiple objects per file.
+"""
+
+from __future__ import absolute_import
+import json
+
+
+def dump(value, fp):
+    "Serialize value as json line to a byte-mode file object"
+    fp.write(json.dumps(value).encode())
+    fp.write(b"\n")
+
+
+def dumps(value):
+    "Serialize value as json to bytes"
+    return json.dumps(value).encode()
+
+
+def load(fp):
+    "Deserialize one json line from a byte-mode file object"
+    return json.loads(fp.readline().decode())
+
+
+def loads(bytes_value):
+    "Deserialize one json value from bytes"
+    return json.loads(bytes_value.decode())

--- a/persistqueue/serializers/msgpack.py
+++ b/persistqueue/serializers/msgpack.py
@@ -1,0 +1,34 @@
+#! coding = utf-8
+
+"""
+A serializer that extends msgpack to specify recommended parameters and adds a
+4 byte length prefix to store multiple objects per file.
+"""
+
+from __future__ import absolute_import
+import msgpack
+import struct
+
+
+def dump(value, fp):
+    "Serialize value as msgpack to a byte-mode file object"
+    packed = msgpack.packb(value, use_bin_type=True)
+    length = struct.pack("<L", len(packed))
+    fp.write(length)
+    fp.write(packed)
+
+
+def dumps(value):
+    "Serialize value as msgpack to bytes"
+    return msgpack.packb(value, use_bin_type=True)
+
+
+def load(fp):
+    "Deserialize one msgpack value from a byte-mode file object"
+    length = struct.unpack("<L", fp.read(4))[0]
+    return msgpack.unpackb(fp.read(length), use_list=False, raw=False)
+
+
+def loads(bytes_value):
+    "Deserialize one msgpack value from bytes"
+    return msgpack.unpackb(bytes_value, use_list=False, raw=False)

--- a/persistqueue/serializers/pickle.py
+++ b/persistqueue/serializers/pickle.py
@@ -1,0 +1,29 @@
+#! coding = utf-8
+
+"""A serializer that extends pickle to change the default protocol"""
+
+from __future__ import absolute_import
+from .. import common
+import pickle
+
+protocol = common.select_pickle_protocol()
+
+
+def dump(value, fp):
+    "Serialize value as pickle to a byte-mode file object"
+    pickle.dump(value, fp, protocol=protocol)
+
+
+def dumps(value):
+    "Serialize value as pickle to bytes"
+    return pickle.dumps(value, protocol=protocol)
+
+
+def load(fp):
+    "Deserialize one pickle value from a byte-mode file object"
+    return pickle.load(fp)
+
+
+def loads(bytes_value):
+    "Deserialize one pickle value from bytes"
+    return pickle.loads(bytes_value)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 mock>=2.0.0
 flake8>=3.2.1
 eventlet>=0.19.0
+msgpack>=0.5.6
 nose2>=0.6.5
 coverage!=4.5
 cov_core>=1.15.0

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -7,9 +7,22 @@ import shutil
 import sys
 import tempfile
 import unittest
+from collections import namedtuple
+from nose2.tools import params
 from threading import Thread
 
+import persistqueue.serializers.json
+import persistqueue.serializers.msgpack
+import persistqueue.serializers.pickle
 from persistqueue import Queue, Empty, Full
+
+# map keys as params for readable errors from nose
+serializer_params = {
+    "serializer=default": {},
+    "serializer=json": {"serializer": persistqueue.serializers.json},
+    "serializer=msgpack": {"serializer": persistqueue.serializers.msgpack},
+    "serializer=pickle": {"serializer": persistqueue.serializers.pickle},
+}
 
 
 class PersistTest(unittest.TestCase):
@@ -19,26 +32,28 @@ class PersistTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.path, ignore_errors=True)
 
-    def test_open_close_single(self):
+    @params(*serializer_params)
+    def test_open_close_single(self, serializer):
         """Write 1 item, close, reopen checking if same item is there"""
 
-        q = Queue(self.path)
-        q.put(b'var1')
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var1')
         del q
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         self.assertEqual(1, q.qsize())
-        self.assertEqual(b'var1', q.get())
+        self.assertEqual('var1', q.get())
         q.task_done()
 
-    def test_open_close_1000(self):
+    @params(*serializer_params)
+    def test_open_close_1000(self, serializer):
         """Write 1000 items, close, reopen checking if all items are there"""
 
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         for i in range(1000):
             q.put('var%d' % i)
         self.assertEqual(1000, q.qsize())
         del q
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         self.assertEqual(1000, q.qsize())
         for i in range(1000):
             data = q.get()
@@ -47,19 +62,20 @@ class PersistTest(unittest.TestCase):
         with self.assertRaises(Empty):
             q.get_nowait()
         # assert adding another one still works
-        q.put(b'foobar')
+        q.put('foobar')
         data = q.get()
 
-    def test_partial_write(self):
+    @params(*serializer_params)
+    def test_partial_write(self, serializer):
         """Test recovery from previous crash w/ partial write"""
 
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         for i in range(100):
             q.put('var%d' % i)
         del q
         with open(os.path.join(self.path, 'q00000'), 'ab') as f:
             pickle.dump('文字化け', f)
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         self.assertEqual(100, q.qsize())
         for i in range(100):
             self.assertEqual('var%d' % i, q.get())
@@ -67,10 +83,11 @@ class PersistTest(unittest.TestCase):
         with self.assertRaises(Empty):
             q.get_nowait()
 
-    def test_random_read_write(self):
+    @params(*serializer_params)
+    def test_random_read_write(self, serializer):
         """Test random read/write"""
 
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
         n = 0
         for i in range(1000):
             if random.random() < 0.5:
@@ -85,10 +102,11 @@ class PersistTest(unittest.TestCase):
                 q.put('var%d' % random.getrandbits(16))
                 n += 1
 
-    def test_multi_threaded(self):
+    @params(*serializer_params)
+    def test_multi_threaded(self, serializer):
         """Create consumer and producer threads, check parallelism"""
 
-        q = Queue(self.path)
+        q = Queue(self.path, **serializer_params[serializer])
 
         def producer():
             for i in range(1000):
@@ -110,81 +128,90 @@ class PersistTest(unittest.TestCase):
         with self.assertRaises(Empty):
             q.get_nowait()
 
-    def test_garbage_on_head(self):
+    @params(*serializer_params)
+    def test_garbage_on_head(self, serializer):
         """Adds garbage to the queue head and let the internal integrity
         checks fix it"""
 
-        q = Queue(self.path)
-        q.put(b'var1')
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var1')
         del q
 
         with open(os.path.join(self.path, 'q00000'), 'ab') as f:
             f.write(b'garbage')
-        q = Queue(self.path)
-        q.put(b'var2')
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var2')
 
         self.assertEqual(2, q.qsize())
-        self.assertEqual(b'var1', q.get())
+        self.assertEqual('var1', q.get())
         q.task_done()
 
-    def test_task_done_too_many_times(self):
+    @params(*serializer_params)
+    def test_task_done_too_many_times(self, serializer):
         """Test too many task_done called."""
-        q = Queue(self.path)
-        q.put(b'var1')
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var1')
         q.get()
         q.task_done()
 
         with self.assertRaises(ValueError):
             q.task_done()
 
-    def test_get_timeout_negative(self):
-        q = Queue(self.path)
-        q.put(b'var1')
+    @params(*serializer_params)
+    def test_get_timeout_negative(self, serializer):
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var1')
         with self.assertRaises(ValueError):
             q.get(timeout=-1)
 
-    def test_get_timeout(self):
+    @params(*serializer_params)
+    def test_get_timeout(self, serializer):
         """Test when get failed within timeout."""
-        q = Queue(self.path)
-        q.put(b'var1')
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put('var1')
         q.get()
         with self.assertRaises(Empty):
             q.get(timeout=1)
 
-    def test_put_nowait(self):
+    @params(*serializer_params)
+    def test_put_nowait(self, serializer):
         """Tests the put_nowait interface."""
-        q = Queue(self.path)
-        q.put_nowait(b'var1')
-        self.assertEqual(b'var1', q.get())
+        q = Queue(self.path, **serializer_params[serializer])
+        q.put_nowait('var1')
+        self.assertEqual('var1', q.get())
         q.task_done()
 
-    def test_put_maxsize_reached(self):
+    @params(*serializer_params)
+    def test_put_maxsize_reached(self, serializer):
         """Test that maxsize reached."""
-        q = Queue(self.path, maxsize=10)
+        q = Queue(self.path, maxsize=10, **serializer_params[serializer])
         for x in range(10):
             q.put(x)
 
         with self.assertRaises(Full):
-            q.put(b'full_now', block=False)
+            q.put('full_now', block=False)
 
-    def test_put_timeout_reached(self):
+    @params(*serializer_params)
+    def test_put_timeout_reached(self, serializer):
         """Test put with block and timeout."""
-        q = Queue(self.path, maxsize=2)
+        q = Queue(self.path, maxsize=2, **serializer_params[serializer])
         for x in range(2):
             q.put(x)
 
         with self.assertRaises(Full):
-            q.put(b'full_and_timeout', block=True, timeout=1)
+            q.put('full_and_timeout', block=True, timeout=1)
 
-    def test_put_timeout_negative(self):
+    @params(*serializer_params)
+    def test_put_timeout_negative(self, serializer):
         """Test and put with timeout < 0"""
-        q = Queue(self.path, maxsize=1)
+        q = Queue(self.path, maxsize=1, **serializer_params[serializer])
         with self.assertRaises(ValueError):
-            q.put(b'var1', timeout=-1)
+            q.put('var1', timeout=-1)
 
-    def test_put_block_and_wait(self):
+    @params(*serializer_params)
+    def test_put_block_and_wait(self, serializer):
         """Test block until queue is not full."""
-        q = Queue(self.path, maxsize=10)
+        q = Queue(self.path, maxsize=10, **serializer_params[serializer])
 
         def consumer():
             for i in range(5):
@@ -204,16 +231,17 @@ class PersistTest(unittest.TestCase):
         p.join()
         self.assertEqual('var5', val)
 
-    def test_clear_tail_file(self):
-        """Teat that only remove tail file when calling task_done."""
-        q = Queue(self.path, chunksize=10)
+    @params(*serializer_params)
+    def test_clear_tail_file(self, serializer):
+        """Test that only remove tail file when calling task_done."""
+        q = Queue(self.path, chunksize=10, **serializer_params[serializer])
         for i in range(35):
             q.put('var%d' % i)
 
         for _ in range(15):
             q.get()
 
-        q = Queue(self.path, chunksize=10)
+        q = Queue(self.path, chunksize=10, **serializer_params[serializer])
         self.assertEqual(q.qsize(), 35)
 
         for _ in range(15):
@@ -226,12 +254,18 @@ class PersistTest(unittest.TestCase):
         q.task_done()
         self.assertEqual(q.qsize(), 4)
 
-    def test_protocol_1(self):
-        shutil.rmtree(self.path)
+    def test_protocol(self):
+        # test that protocol is set properly
+        expect_protocol = 2 if sys.version_info[0] == 2 else 4
+        self.assertEqual(
+            persistqueue.serializers.pickle.protocol,
+            expect_protocol,
+        )
 
-        q = Queue(path=self.path)
-        self.assertEqual(q.protocol, 2 if sys.version_info[0] == 2 else 4)
+        # test that protocol is used properly
+        serializer = namedtuple("Serializer", ["dump", "load"])(
+                persistqueue.serializers.pickle.dump, lambda fp: fp.read())
 
-    def test_protocol_2(self):
-        q = Queue(path=self.path)
-        self.assertEqual(q.protocol, None)
+        q = Queue(path=self.path, serializer=serializer)
+        q.put(b'a')
+        self.assertEqual(q.get(), pickle.dumps(b'a', protocol=expect_protocol))


### PR DESCRIPTION
I'm interested in using this library, but I'm hesitant to use pickling.

Is it allowable for me to submit some PRs that make it possible to configure another serializer, such as json or msgpack?

Also, this PR should fix a couple bugs:
* if `path` exists, such as when resuming a queue after restart, then `self.protocol` would be `None`
* `_put()` wasn't actually using `self.protocol`, so it would fall back to version 0