### PR TITLE
[GH-56]Fix queue file corruption after reset

### DIFF
--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -156,6 +156,9 @@ class Queue(object):
         if hpos == self.info['chunksize']:
             hpos = 0
             hnum += 1
+            # make sure data is written to disk whatever
+            # its underlying file system
+            os.fsync(self.headf.fileno())
             self.headf.close()
             self.headf = self._openchunk(hnum, 'ab+')
         self.info['size'] += 1


### PR DESCRIPTION
When running file queue on some system configurations(eg, ext4 with
data=journal), the queue data written were not synced to
disk immediately, so a system reset/crash can corrupt the queue file.

This commit force a fsync before closing the queue file, such
ensure data written is flushed to disk.