### PR TITLE
[GH-58]set text_factory to str after restart

### DIFF
--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -101,9 +101,8 @@ class SQLiteBase(object):
             if not self.memory_sql:
                 self._putter = self._new_db_connection(
                     self.path, self.multithreading, self.timeout)
-        if self.protocol is not None:
-            self._conn.text_factory = str
-            self._putter.text_factory = str
+        self._conn.text_factory = str
+        self._putter.text_factory = str
 
         # SQLite3 transaction lock
         self.tran_lock = threading.Lock()


### PR DESCRIPTION
Currently, if start a new queue object on an existing path
the text_factory of sqlite3 is not set which caused following issue:
  "OperationalError: Could not decode to UTF-8 column 'data' with text"

This commit set the text_factory to str if starting on an existing
path