### PR TITLE
[GH-64]Automatic select temp dir

### DIFF
--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -1,0 +1,1 @@
+msgpack

--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -12,7 +12,6 @@ from time import time as _time
 import persistqueue.serializers.pickle
 from persistqueue.exceptions import Empty, Full
 
-
 log = logging.getLogger(__name__)
 
 
@@ -31,7 +30,7 @@ def atomic_rename(src, dst):
             import ctypes
 
             if sys.version_info[0] == 2:
-                _str = unicode # noqa
+                _str = unicode  # noqa
                 _bytes = str
             else:
                 _str = str
@@ -88,6 +87,16 @@ class Queue(object):
             if os.stat(self.path).st_dev != os.stat(self.tempdir).st_dev:
                 raise ValueError("tempdir has to be located "
                                  "on same path filesystem")
+        else:
+            _, tempdir = tempfile.mkstemp()
+            if os.stat(self.path).st_dev != os.stat(tempdir).st_dev:
+                self.tempdir = self.path
+                log.warning("Default tempdir '%(dft_dir)s' is not on the "
+                            "same filesystem with queue path '%(queue_path)s'"
+                            ",defaulting to '%(new_path)s'." % {
+                                "dft_dir": tempdir,
+                                "queue_path": self.path,
+                                "new_path": self.tempdir})
         self.info = self._loadinfo()
         # truncate head case it contains garbage
         hnum, hcnt, hoffset = self.info['head']

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@
 
 from setuptools import setup, find_packages
 
+
+def get_extras():
+    return {
+        "EXTRA": open("extra-requirements.txt").read().splitlines()
+    }
+
+
 setup(
     name='persist-queue',
     version=__import__('persistqueue').__version__,
@@ -16,6 +23,7 @@ setup(
     maintainer_email='wangxu198709@gmail.com',
     license=__import__('persistqueue').__license__,
     packages=find_packages(),
+    extras_require=get_extras(),
     platforms=["all"],
     url='http://github.com/peter-wangxu/persist-queue',
     classifiers=[


### PR DESCRIPTION
If the tmp dir was not on the same partition of
the queue path, we need to set the temp dir to
queue path so that os.rename can work as expected