### PR TITLE
[GH-79]Fix issue when storing 0 as value

### DIFF
--- a/persistqueue/__init__.py
+++ b/persistqueue/__init__.py
@@ -9,7 +9,7 @@ try:
     from .pdict import PDict  # noqa
     from .sqlqueue import SQLiteQueue, FIFOSQLiteQueue, FILOSQLiteQueue, UniqueQ  # noqa
     from .sqlackqueue import SQLiteAckQueue
-except ImportError as error:
+except ImportError:
     import logging
     log = logging.getLogger(__name__)
     log.info("No sqlite3 module found, sqlite3 based queues are not available")

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -177,12 +177,12 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
     def get(self, block=True, timeout=None):
         if not block:
             serialized = self._pop()
-            if not serialized:
+            if serialized is None:
                 raise Empty
         elif timeout is None:
             # block until a put event.
             serialized = self._pop()
-            while not serialized:
+            while serialized is None:
                 self.put_event.clear()
                 self.put_event.wait(TICK_FOR_WAIT)
                 serialized = self._pop()
@@ -192,7 +192,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             # block until the timeout reached
             endtime = _time.time() + timeout
             serialized = self._pop()
-            while not serialized:
+            while serialized is None:
                 self.put_event.clear()
                 remaining = endtime - _time.time()
                 if remaining <= 0.0:

--- a/persistqueue/sqlqueue.py
+++ b/persistqueue/sqlqueue.py
@@ -81,7 +81,7 @@ class SQLiteQueue(sqlbase.SQLiteBase):
         elif timeout is None:
             # block until a put event.
             serialized = self._pop()
-            while not serialized:
+            while serialized is None:
                 self.put_event.clear()
                 self.put_event.wait(TICK_FOR_WAIT)
                 serialized = self._pop()

--- a/tests/test_sqlackqueue.py
+++ b/tests/test_sqlackqueue.py
@@ -273,6 +273,12 @@ class SQLite3AckQueueTest(unittest.TestCase):
         self.assertEqual(q.acked_count(), 2)
         self.assertEqual(q.ready_count(), 0)
 
+    def test_put_0(self):
+        q = SQLiteAckQueue(path=self.path)
+        q.put(0)
+        d = q.get(block=False)
+        self.assertIsNotNone(d)
+
 
 class SQLite3QueueInMemory(SQLite3AckQueueTest):
     def setUp(self):

--- a/tests/test_sqlqueue.py
+++ b/tests/test_sqlqueue.py
@@ -7,9 +7,9 @@ import tempfile
 import unittest
 from threading import Thread
 
-import persistqueue.serializers
 from persistqueue import SQLiteQueue, FILOSQLiteQueue, UniqueQ
 from persistqueue import Empty
+from persistqueue.serializers import json as internal_json
 
 
 class SQLite3QueueTest(unittest.TestCase):
@@ -212,7 +212,7 @@ class SQLite3QueueTest(unittest.TestCase):
     def test_json_serializer(self):
         q = SQLiteQueue(
             path=self.path,
-            serializer=persistqueue.serializers.json)
+            serializer=internal_json)
         x = dict(
             a=1,
             b=2,
@@ -222,6 +222,12 @@ class SQLite3QueueTest(unittest.TestCase):
             ))
         q.put(x)
         self.assertEquals(q.get(), x)
+
+    def test_put_0(self):
+        q = SQLiteQueue(path=self.path)
+        q.put(0)
+        d = q.get(block=False)
+        self.assertIsNotNone(d)
 
 
 class SQLite3QueueNoAutoCommitTest(SQLite3QueueTest):


### PR DESCRIPTION
the 0 was treated as an invalid user input incorrectly,
so that 0 was ignored when `get` and user may be blocked if 0 is
the last value in the queue