### PR TITLE
Fix UniqueQueue dictionary problem with json serializer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,11 @@ jobs:
       - store_artifacts:
           # collect core dumps
           path: /tmp/core_dumps
+      - store_artifacts:
           path: .coverage
+      - store_artifacts:
           path: coverage.xml
+      - store_artifacts:
           path: htmlcov
 
   py34:

--- a/persistqueue/serializers/__init__.py
+++ b/persistqueue/serializers/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ["json", "msgpack", "pickle"]
+
+from persistqueue.serializers import json
+from persistqueue.serializers import msgpack
+from persistqueue.serializers import pickle

--- a/persistqueue/serializers/json.py
+++ b/persistqueue/serializers/json.py
@@ -11,13 +11,13 @@ import json
 
 def dump(value, fp):
     "Serialize value as json line to a byte-mode file object"
-    fp.write(json.dumps(value).encode())
+    fp.write(json.dumps(value, sort_keys=True).encode())
     fp.write(b"\n")
 
 
 def dumps(value):
     "Serialize value as json to bytes"
-    return json.dumps(value).encode()
+    return json.dumps(value, sort_keys=True).encode()
 
 
 def load(fp):

--- a/persistqueue/serializers/json.py
+++ b/persistqueue/serializers/json.py
@@ -9,15 +9,15 @@ from __future__ import absolute_import
 import json
 
 
-def dump(value, fp):
+def dump(value, fp, sort_keys=False):
     "Serialize value as json line to a byte-mode file object"
-    fp.write(json.dumps(value, sort_keys=True).encode())
+    fp.write(json.dumps(value, sort_keys=sort_keys).encode())
     fp.write(b"\n")
 
 
-def dumps(value):
+def dumps(value, sort_keys=False):
     "Serialize value as json to bytes"
-    return json.dumps(value, sort_keys=True).encode()
+    return json.dumps(value, sort_keys=sort_keys).encode()
 
 
 def load(fp):

--- a/persistqueue/serializers/msgpack.py
+++ b/persistqueue/serializers/msgpack.py
@@ -10,16 +10,20 @@ import msgpack
 import struct
 
 
-def dump(value, fp):
+def dump(value, fp, sort_keys=False):
     "Serialize value as msgpack to a byte-mode file object"
+    if sort_keys and isinstance(value, dict):
+        value = {key: value[key] for key in sorted(value)}
     packed = msgpack.packb(value, use_bin_type=True)
     length = struct.pack("<L", len(packed))
     fp.write(length)
     fp.write(packed)
 
 
-def dumps(value):
+def dumps(value, sort_keys=False):
     "Serialize value as msgpack to bytes"
+    if sort_keys and isinstance(value, dict):
+        value = {key: value[key] for key in sorted(value)}
     return msgpack.packb(value, use_bin_type=True)
 
 

--- a/persistqueue/serializers/pickle.py
+++ b/persistqueue/serializers/pickle.py
@@ -9,13 +9,17 @@ import pickle
 protocol = common.select_pickle_protocol()
 
 
-def dump(value, fp):
+def dump(value, fp, sort_keys=False):
     "Serialize value as pickle to a byte-mode file object"
+    if sort_keys and isinstance(value, dict):
+        value = {key: value[key] for key in sorted(value)}
     pickle.dump(value, fp, protocol=protocol)
 
 
-def dumps(value):
+def dumps(value, sort_keys=False):
     "Serialize value as pickle to bytes"
+    if sort_keys and isinstance(value, dict):
+        value = {key: value[key] for key in sorted(value)}
     return pickle.dumps(value, protocol=protocol)
 
 

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -241,7 +241,7 @@ class UniqueAckQ(SQLiteAckQueue):
     )
 
     def put(self, item):
-        obj = self._serializer.dumps(item)
+        obj = self._serializer.dumps(item, sort_keys=True)
         try:
             self._insert_into(obj, _time.time())
         except sqlite3.IntegrityError:

--- a/persistqueue/sqlqueue.py
+++ b/persistqueue/sqlqueue.py
@@ -138,7 +138,7 @@ class UniqueQ(SQLiteQueue):
                    'data BLOB, timestamp FLOAT, UNIQUE (data))')
 
     def put(self, item):
-        obj = self._serializer.dumps(item)
+        obj = self._serializer.dumps(item, sort_keys=True)
         try:
             self._insert_into(obj, _time.time())
         except sqlite3.IntegrityError:

--- a/persistqueue/tests/test_sqlqueue.py
+++ b/persistqueue/tests/test_sqlqueue.py
@@ -9,7 +9,7 @@ from threading import Thread
 
 from persistqueue import SQLiteQueue, FILOSQLiteQueue, UniqueQ
 from persistqueue import Empty
-from persistqueue.serializers import json as internal_json
+from persistqueue import serializers
 
 
 class SQLite3QueueTest(unittest.TestCase):
@@ -212,7 +212,7 @@ class SQLite3QueueTest(unittest.TestCase):
     def test_json_serializer(self):
         q = SQLiteQueue(
             path=self.path,
-            serializer=internal_json)
+            serializer=serializers.json)
         x = dict(
             a=1,
             b=2,
@@ -374,9 +374,37 @@ class SQLite3UniqueQueueTest(unittest.TestCase):
 
         self.assertEqual(len(set(counter)), len(counter))
 
-    def test_unique_dictionary_serialization(self):
-        queue = UniqueQ(path=self.path, multithreading=True,
-                        auto_commit=self.auto_commit)
+    def test_unique_dictionary_serialization_pickle(self):
+        queue = UniqueQ(
+            path=self.path,
+            multithreading=True,
+            auto_commit=self.auto_commit,
+            serializer=serializers.pickle,
+        )
+        queue.put({"foo": 1, "bar": 2})
+        self.assertEqual(queue.total, 1)
+        queue.put({"bar": 2, "foo": 1})
+        self.assertEqual(queue.total, 1)
+
+    def test_unique_dictionary_serialization_msgpack(self):
+        queue = UniqueQ(
+            path=self.path,
+            multithreading=True,
+            auto_commit=self.auto_commit,
+            serializer=serializers.msgpack
+        )
+        queue.put({"foo": 1, "bar": 2})
+        self.assertEqual(queue.total, 1)
+        queue.put({"bar": 2, "foo": 1})
+        self.assertEqual(queue.total, 1)
+
+    def test_unique_dictionary_serialization_json(self):
+        queue = UniqueQ(
+            path=self.path,
+            multithreading=True,
+            auto_commit=self.auto_commit,
+            serializer=serializers.json
+        )
         queue.put({"foo": 1, "bar": 2})
         self.assertEqual(queue.total, 1)
         queue.put({"bar": 2, "foo": 1})

--- a/persistqueue/tests/test_sqlqueue.py
+++ b/persistqueue/tests/test_sqlqueue.py
@@ -373,3 +373,11 @@ class SQLite3UniqueQueueTest(unittest.TestCase):
                                 "not 0 for counter's index %s" % x)
 
         self.assertEqual(len(set(counter)), len(counter))
+
+    def test_unique_dictionary_serialization(self):
+        queue = UniqueQ(path=self.path, multithreading=True,
+                        auto_commit=self.auto_commit)
+        queue.put({"foo": 1, "bar": 2})
+        self.assertEqual(queue.total, 1)
+        queue.put({"bar": 2, "foo": 1})
+        self.assertEqual(queue.total, 1)


### PR DESCRIPTION
The problem this pull request is trying to solve is the following:

```python
>>> d1 = {"foo": 1, "bar": 2}
>>> d2 = {"bar": 2, "foo": 1}
>>> json.dumps(d1)
'{"foo": 1, "bar": 2}'
>>> json.dumps(d2)
'{"bar": 2, "foo": 1}'
```

Order of keys depends on the dictionary initialization order. But if we force `sort_keys` then the encoded values will be identical which will solve the problem with `UniequeQueue`

```python
>>> json.dumps(d1, sort_keys=True) == json.dumps(d2, sort_keys=True)
True
```

There is no simple way to solve this problem with the `msgpack` or `pickle` serializer, except doing something like this:

```python
if isinstance(obj, dict):
    obj = {
        key: obj[key]
        in sorted(obj)
    }
pickle/msgpack.dumps(obj)
```

```python
>>> (
    msgpack.dumps({key: d1[key] for key in sorted(d1)}) ==
    msgpack.dumps({key: d2[key] for key in sorted(d2)})
)
True
```

But this will slow things up so I didn't include it in the pull request.

Actually event the `sort_keys` slows things up.

```python
>>> d = {
    i: str(i)
    for i in reversed(range(10000))
}
>>> %%timeit -n 100 -r 100
    x = json.dumps(d)
2.05 ms ± 104 µs per loop (mean ± std. dev. of 100 runs, 100 loops each)

>>> %%timeit -n 100 -r 100
    x = json.dumps(d, sort_keys=True)
2.34 ms ± 77.1 µs per loop (mean ± std. dev. of 100 runs, 100 loops each)
```

So I will cry just a little bit, not too much if you reject the pull request 🤣 