### PR TITLE
fix AttributeError in Queue.__del__

### DIFF
--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -296,6 +296,6 @@ class Queue(object):
 
     def __del__(self):
         """Handles the removal of queue."""
-        for to_close in [self.headf, self.tailf, self.info]:
+        for to_close in [self.headf, self.tailf]:
             if to_close and not to_close.closed:
                 to_close.close()

--- a/persistqueue/tests/test_queue.py
+++ b/persistqueue/tests/test_queue.py
@@ -281,3 +281,11 @@ class PersistTest(unittest.TestCase):
         q = Queue(path=self.path, serializer=serializer)
         q.put(b'a')
         self.assertEqual(q.get(), pickle.dumps(b'a', protocol=expect_protocol))
+
+    @params(*serializer_params)
+    def test_del(self, serializer):
+        """test that __del__ can be called successfully"""
+        q = Queue(self.path, **serializer_params[serializer])
+        q.__del__()
+        self.assertTrue(q.headf.closed)
+        self.assertTrue(q.tailf.closed)


### PR DESCRIPTION
`Queue.__del__` attempts to use `closed` and `close()` on `self.info`, but `self.info` is a dict and there's nothing to close. Just removing it from the removal list.

example (python 3.6):
```
>>> from persistqueue import Queue
>>> q = Queue('/tmp')
>>> del q
Exception ignored in: <bound method Queue.__del__ of <persistqueue.queue.Queue object at 0x7f01a45d0cc0>>
Traceback (most recent call last):
  File "/home/ahusak/scratch/persist-queue/persistqueue/queue.py", line 300, in __del__
    if to_close and not to_close.closed:
AttributeError: 'dict' object has no attribute 'closed'
```

I think because this happens in `__del__`, you can see the exception is ignored rather than raised. So the unit tests definitely complain about this but succeed regardless. Not sure how to write a unit_test around that very peculiar scenario.
 