### PR TITLE
add optional autosave feature to file Queue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,62 @@ Close the python console, and then we restart the queue from the same path,
     'b'
     >>> q.task_done()
 
+Example usage with an auto-saving file based queue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By default, items added to the queue are persisted during the ``put()`` call,
+and items removed from a queue are only persisted when ``task_done()`` is
+called.
+
+.. code-block:: python
+
+    >>> from persistqueue import Queue
+    >>> q = Queue("mypath")
+    >>> q.put('a')
+    >>> q.put('b')
+    >>> q.get()
+    'a'
+    >>> q.get()
+    'b'
+
+After exiting and restarting the queue from the same path, we see the items
+remain in the queue, because ``task_done()`` wasn't called before.
+
+.. code-block:: python
+
+    >>> from persistqueue import Queue
+    >>> q = Queue('mypath')
+    >>> q.get()
+    'a'
+    >>> q.get()
+    'b'
+
+This can be advantageous. For example, if your program crashes before finishing
+processing an item, it will remain in the queue after restarting. You can also
+spread out the ``task_done()`` calls for performance reasons to avoid lots of
+individual writes.
+
+Using ``autosave=True`` on a file based queue will automatically save on every
+call to ``get()``. Calling ``task_done()`` is not necessary, but may still be
+used to ``join()`` against the queue.
+
+.. code-block:: python
+
+    >>> from persistqueue import Queue
+    >>> q = Queue("mypath", autosave=True)
+    >>> q.put('a')
+    >>> q.put('b')
+    >>> q.get()
+    'a'
+
+After exiting and restarting the queue from the same path, only the second item
+remains:
+
+.. code-block:: python
+
+    >>> from persistqueue import Queue
+    >>> q = Queue('mypath', autosave=True)
+    >>> q.get()
+    'b'
 
 
 Example usage with a SQLite3 based dict

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -53,6 +53,19 @@ class FileQueueBench(object):
         assert q.qsize() == 0
 
     @time_it
+    def benchmark_file_read_write_autosave(self):
+        """Writing and reading <BENCHMARK_COUNT> items(autosave)."""
+
+        self.path = tempfile.mkdtemp('b_file_10000')
+        q = Queue(self.path, autosave=True)
+        for i in range(BENCHMARK_COUNT):
+            q.put('bench%d' % i)
+
+        for i in range(BENCHMARK_COUNT):
+            q.get()
+        assert q.qsize() == 0
+
+    @time_it
     def benchmark_file_read_write_true(self):
         """Writing and reading <BENCHMARK_COUNT> items(many task_done)."""
 


### PR DESCRIPTION
Adds an optional `autosave` parameter to the file Queue, which will automatically save on `get()` rather than a separate call to `task_done()`. Existing behavior remains the same, it should be backwards compatible.

I went with the name `autosave` as `auto_commit` has specific meaning to SQL and thought it might be confusing. I can rename it if you'd prefer something different.

I also kept `task_done()` behavior the same _except_ for the actual file saving to allow the most flexibility in usage. The "counting" that `task_done()` does will still work with `join()` regardless of enabling `autosave`.

I added some language in the class docstring as well as the readme. Not sure if I'm being too wordy so I can try and chop it down if necessary. I'm open to suggestions.

I also updated the run_benchmark.py to include the feature. It's basically equivalent to "many task_done" (as you'd expect):

```
<BENCHMARK_COUNT> = 100
Benchmark File queue performance.
        Writing and reading <BENCHMARK_COUNT> items(autosave). => time used: 0.0419 seconds.
        Writing and reading <BENCHMARK_COUNT> items(1 task_done). => time used: 0.0172 seconds.
        Writing and reading <BENCHMARK_COUNT> items(many task_done). => time used: 0.0461 seconds.
        Writing <BENCHMARK_COUNT> items. => time used: 0.0161 seconds.

<BENCHMARK_COUNT> = 1000
Benchmark File queue performance.
        Writing and reading <BENCHMARK_COUNT> items(autosave). => time used: 0.2969 seconds.
        Writing and reading <BENCHMARK_COUNT> items(1 task_done). => time used: 0.2061 seconds.
        Writing and reading <BENCHMARK_COUNT> items(many task_done). => time used: 0.3096 seconds.
        Writing <BENCHMARK_COUNT> items. => time used: 0.1984 seconds.

<BENCHMARK_COUNT> = 10000
Benchmark File queue performance.
        Writing and reading <BENCHMARK_COUNT> items(autosave). => time used: 2.8344 seconds.
        Writing and reading <BENCHMARK_COUNT> items(1 task_done). => time used: 1.6721 seconds.
        Writing and reading <BENCHMARK_COUNT> items(many task_done). => time used: 2.6877 seconds.
        Writing <BENCHMARK_COUNT> items. => time used: 1.4370 seconds.
```

implements #116 