### PR TITLE
Empty and Full inheriting from python.queue exceptions

### DIFF
--- a/persistqueue/exceptions.py
+++ b/persistqueue/exceptions.py
@@ -1,9 +1,19 @@
 #! coding = utf-8
+try:
+    from queue import (
+        Empty as StdEmpty,
+        Full as StdFull
+    )
+except ImportError:
+    from Queue import (
+        Empty as StdEmpty,
+        Full as StdFull
+    )
 
 
-class Empty(Exception):
+class Empty(StdEmpty):
     pass
 
 
-class Full(Exception):
+class Full(StdFull):
     pass


### PR DESCRIPTION
Hello again @peter-wangxu, this is a proposition of making `persistqueue.exceptions` inherit from their standard python `queue` counterparts. I propose this because right now, you cannot make code like this work (when using a `persistqueue` queue of course):

```python
from queue import Empty

try:
  queue.get_nowait()
except Empty:
   print('empty!')
```

Which means that if you want to use `persistqueue` with code that has been written with python queues in mind, this won't seemlessly work.