### PR TITLE
Adding PDict.get

### DIFF
--- a/persistqueue/pdict.py
+++ b/persistqueue/pdict.py
@@ -62,6 +62,12 @@ class PDict(sqlbase.SQLiteBase, dict):
         else:
             raise KeyError('Key: {} not exists.'.format(item))
 
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def __delitem__(self, key):
         self._delete(key)
 

--- a/persistqueue/tests/test_pdict.py
+++ b/persistqueue/tests/test_pdict.py
@@ -34,6 +34,9 @@ class PDictTest(unittest.TestCase):
         self.assertEqual(pd['key_a'], 'value_a')
         self.assertTrue('key_a' in pd)
         self.assertFalse('key_b' in pd)
+        self.assertEqual(pd.get('key_a'), 'value_a')
+        self.assertEqual(pd.get('key_b'), None)
+        self.assertEqual(pd.get('key_b', 'absent'), 'absent')
         self.assertRaises(KeyError, lambda: pd['key_b'])
         pd['key_b'] = 'value_b'
         self.assertEqual(pd['key_a'], 'value_a')
@@ -45,6 +48,8 @@ class PDictTest(unittest.TestCase):
         pd['key_b'] = 'value_b'
         self.assertEqual(pd['key_a'], 'value_a')
         self.assertEqual(pd['key_b'], 'value_b')
+        self.assertEqual(pd.get('key_a'), 'value_a')
+        self.assertEqual(pd.get('key_b', 'absent'), 'value_b')
         pd['key_a'] = 'value_aaaaaa'
         self.assertEqual(pd['key_a'], 'value_aaaaaa')
         self.assertEqual(pd['key_b'], 'value_b')


### PR DESCRIPTION
Just a PR adding the `#.get` method to the `PDict`. This method exists on python's `dict` and has been replicated with its default argument. The only compromise I made was to make `default` a kwarg while python's own implementation does not recognize second argument as kwarg (I can edit the PR to march closely what python does by using `*args` which makes the implementation a bit more complex).

This method is often very useful if you want to test existence of an item in the dict as well as getting the attached value in a single operation. This is even truer with the `PDict` since making those two operations would require two SQL queries whereas here only one is sufficient.