### PR TITLE
Fix end of queue increment

### DIFF
--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from inspect import trace
 
 import logging
 import sqlite3
@@ -77,7 +78,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
     def resume_unack_tasks(self):
         unack_count = self.unack_count()
         if unack_count:
-            log.warning("resume %d unack tasks", unack_count)
+            log.info("resume %d unack tasks", unack_count)
         sql = 'UPDATE {} set status = ?' \
               ' WHERE status = ?'.format(self._table_name)
         with self.tran_lock:
@@ -204,11 +205,11 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
             for key, value in self._unack_cache.items():
                 if value is item:
                     return key
-            log.warning("Can't find item in unack cache.")
         elif isinstance(item, int) or (
             isinstance(item, str) and item.isnumeric()
         ):
             return int(item)
+        log.warning("Item id not Interger and can't find item in unack cache.")
         return None
 
     def _check_id(self, item, id):

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from inspect import trace
 
 import logging
 import sqlite3

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -117,11 +117,10 @@ class SQLiteBase(object):
         self._conn.execute(self._sql_create)
         self._conn.commit()
         # Setup another session only for disk-based queue.
-        if self.multithreading:
-            if not self.memory_sql:
-                self._putter = self._new_db_connection(
-                    self.path, self.multithreading, self.timeout
-                )
+        if self.multithreading and not self.memory_sql:
+            self._putter = self._new_db_connection(
+                self.path, self.multithreading, self.timeout
+            )
         self._conn.text_factory = str
         self._putter.text_factory = str
 
@@ -186,7 +185,7 @@ class SQLiteBase(object):
             and rowid != start_key
             and (not result or len(result) == 0)
         ):
-            # sqlackqueue: if we're at the end, start over - loop incremental
+            # sqlackqueue: if we're at the end, start over
             kwargs['rowid'] = start_key
             result = self._select(*args, **kwargs)
         return result

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -188,7 +188,7 @@ class SQLiteBase(object):
         ):
             # sqlackqueue: if we're at the end, start over - loop incremental
             kwargs['rowid'] = start_key
-            result = self._select(args=args, kwargs=kwargs)
+            result = self._select(*args, **kwargs)
         return result
 
     def _count(self):


### PR DESCRIPTION
Seems the prior code didn't work properly and ends up creating a variable of kargs that is equal to **kargs instead of actually just passing the values of kargs.  Same with args.  Did a test and just passing `*args, **kargs` directly will pass the variables properly.