### PR TITLE
Create an index on the status column

### DIFF
--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -41,7 +41,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
     )
     # SQL to index the status
     _SQL_INDEX = (
-        'CREATE INDEX status_idx ON {table_name} (status)'
+        'CREATE INDEX IF NOT EXISTS status_idx ON {table_name} (status)'
     )
     # SQL to insert a record
     _SQL_INSERT = (

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -39,6 +39,10 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
         '{key_column} INTEGER PRIMARY KEY AUTOINCREMENT, '
         'data BLOB, timestamp FLOAT, status INTEGER)'
     )
+    # SQL to index the status
+    _SQL_INDEX = (
+        'CREATE INDEX status_idx ON {table_name} (status)'
+    )
     # SQL to insert a record
     _SQL_INSERT = (
         'INSERT INTO {table_name} (data, timestamp, status)'

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -191,7 +191,7 @@ class SQLiteBase(object):
         ):
             # sqlackqueue: if we're at the end, start over - loop incremental
             kwargs['rowid'] = start_key
-            result = self._select(*args, **kwargs)
+            result = self._select(args=args, kwargs=kwargs)
         return result
 
     def _count(self):

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -46,6 +46,7 @@ class SQLiteBase(object):
     _TABLE_NAME = 'base'  # DB table name
     _KEY_COLUMN = ''  # the name of the key column, used in DB CRUD
     _SQL_CREATE = ''  # SQL to create a table
+    _SQL_INDEX = ''  # SQL to index a table
     _SQL_UPDATE = ''  # SQL to update a record
     _SQL_INSERT = ''  # SQL to insert a record
     _SQL_SELECT = ''  # SQL to select a record
@@ -115,6 +116,8 @@ class SQLiteBase(object):
         self._putter = self._conn
 
         self._conn.execute(self._sql_create)
+        if len(self._SQL_INDEX) > 0:
+            self._conn.execute(self._sql_index)
         self._conn.commit()
         # Setup another session only for disk-based queue.
         if self.multithreading:
@@ -188,7 +191,7 @@ class SQLiteBase(object):
         ):
             # sqlackqueue: if we're at the end, start over - loop incremental
             kwargs['rowid'] = start_key
-            result = self._select(args=args, kwargs=kwargs)
+            result = self._select(*args, **kwargs)
         return result
 
     def _count(self):
@@ -225,6 +228,10 @@ class SQLiteBase(object):
         return self._SQL_CREATE.format(
             table_name=self._table_name, key_column=self._key_column
         )
+
+    @property
+    def _sql_index(self):
+        return self._SQL_INDEX.format(table_name=self._table_name)
 
     @property
     def _sql_insert(self):


### PR DESCRIPTION
Since the status is used in the WHERE statement of the SQLAckQueue, I think t makes performance sense to index it.

Note: I haven't performance tested this.  I'm making assumptions based on normal practice, but since the status is updated regularly, I don't know if indexing creates overhead that negates the performance gain.  I would suspect it to greatly reduce (improve) the get query time and slightly increase (delay) the ack, nack time.