### PR TITLE
Add `shrink_disk_usage` for sqlite3 base queues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,11 @@ Close the console, and then recreate the queue:
    'str2'
    >>>
 
+New functions:
+*Available since v0.8.0*
+
+- ``shrink_disk_usage`` perform a ``VACUUM`` against the sqlite, and rebuild the database file, this usually takes long time and frees a lot of disk space after ``get()``
+
 
 Example usage of SQLite3 based ``UniqueQ``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/persistqueue/__init__.py
+++ b/persistqueue/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 __author__ = 'Peter Wang'
 __license__ = 'BSD'
-__version__ = '0.8.0-alpha0'
+__version__ = '0.8.0-beta0'
 
 from .exceptions import Empty, Full  # noqa
 from .queue import Queue  # noqa

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -167,11 +167,6 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
         )
         return sql, AckStatus.acked
 
-    @sqlbase.with_conditional_transaction
-    def shrink_disk_usage(self):
-        sql = """VACUUM"""
-        return sql, ()
-
     @property
     def _sql_mark_ack_status(self):
         return self._SQL_MARK_ACK_UPDATE.format(

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -212,6 +212,11 @@ class SQLBase(object):
             datarows.append(item)
         return datarows
 
+    @with_conditional_transaction
+    def shrink_disk_usage(self):
+        sql = """VACUUM"""
+        return sql, ()
+
     @property
     def size(self):
         return self.total

--- a/persistqueue/tests/test_sqlackqueue.py
+++ b/persistqueue/tests/test_sqlackqueue.py
@@ -75,6 +75,7 @@ class SQLite3AckQueueTest(unittest.TestCase):
         # assert adding another one still works
         q.put('foobar')
         data = q.get()
+        q.shrink_disk_usage()
         self.assertEqual('foobar', data)
 
     def test_random_read_write(self):

--- a/persistqueue/tests/test_sqlqueue.py
+++ b/persistqueue/tests/test_sqlqueue.py
@@ -75,6 +75,7 @@ class SQLite3QueueTest(unittest.TestCase):
         # assert adding another one still works
         q.put('foobar')
         data = q.get()
+        q.shrink_disk_usage()
         self.assertEqual('foobar', data)
 
     def test_random_read_write(self):


### PR DESCRIPTION
Performs a ``VACUUM`` against the sqlite, and rebuild the database file, this usually takes long time and frees a lot of disk space after `get()`

fixes #176