### PR TITLE
Misplaced comma in _sql_mark_ack_status causing function not to be called

### DIFF
--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -126,7 +126,7 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
 
     @sqlbase.with_conditional_transaction
     def _mark_ack_status(self, key, status):
-        return self._sql_mark_ack_status, (
+        return self._sql_mark_ack_status(
             status,
             key,
         )


### PR DESCRIPTION
Is this not a bug? Instead of returning the result you get from calling the function `_sql_mark_ack_status` with the given params, instead you just return the function and the params as a tuple. As a result, the update function never gets called. I have noticed inspecting the .queue() output that the status of all the items I add to the queue always remains as 1 instead of ever being changed to 2 like this function is supposed to. This also could potentially be the cause of the bug you are talking about on line 179.