### PR TITLE
Add full() API and tests

### DIFF
--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -152,6 +152,9 @@ class Queue(object):
     def empty(self):
         return self.qsize() == 0
 
+    def full(self):
+        return self.qsize() == self.maxsize
+
     def put(self, item, block=True, timeout=None):
         "Interface for putting item in disk-based queue."
         self.not_full.acquire()

--- a/persistqueue/sqlackqueue.py
+++ b/persistqueue/sqlackqueue.py
@@ -344,6 +344,9 @@ class SQLiteAckQueue(sqlbase.SQLiteBase):
     def empty(self):
         return self.size == 0
 
+    def full(self):
+        return False
+
     def __len__(self):
         return self.size
 

--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -227,6 +227,9 @@ class SQLBase(object):
     def empty(self):
         return self.size == 0
 
+    def full(self):
+        return False
+
     def __len__(self):
         return self.size
 

--- a/persistqueue/tests/test_mysqlqueue.py
+++ b/persistqueue/tests/test_mysqlqueue.py
@@ -74,6 +74,17 @@ class MySQLQueueTest(unittest.TestCase):
         q.get()
         self.assertEqual(q.empty(), True)
 
+    def test_full(self):
+        # SQL queue `full()` always returns `False` !!
+        q = self.queue
+        self.assertEqual(q.full(), False)
+
+        q.put('first')
+        self.assertEqual(q.full(), False)
+
+        q.get()
+        self.assertEqual(q.full(), False)
+
     def test_open_close_single(self):
         """Write 1 item, close, reopen checking if same item is there"""
 

--- a/persistqueue/tests/test_queue.py
+++ b/persistqueue/tests/test_queue.py
@@ -58,6 +58,19 @@ class PersistTest(unittest.TestCase):
         q.get()
         self.assertEqual(q.empty(), True)
 
+    def test_full(self):
+        q = Queue(self.path, maxsize=3)
+
+        for i in range(1, q.maxsize):
+            q.put('var{}'.format(i))
+        self.assertEqual(q.full(), False)
+
+        q.put('var{}'.format(q.maxsize))
+        self.assertEqual(q.full(), True)
+
+        q.get()
+        self.assertEqual(q.full(), False)
+
     @params(*serializer_params)
     def test_open_close_1000(self, serializer):
         """Write 1000 items, close, reopen checking if all items are there"""

--- a/persistqueue/tests/test_sqlackqueue.py
+++ b/persistqueue/tests/test_sqlackqueue.py
@@ -48,6 +48,17 @@ class SQLite3AckQueueTest(unittest.TestCase):
         q.get()
         self.assertEqual(q.empty(), True)
 
+    def test_full(self):
+        # SQL queue `full()` always returns `False` !!
+        q = self.queue_class(self.path, auto_commit=self.auto_commit)
+        self.assertEqual(q.full(), False)
+
+        q.put('first')
+        self.assertEqual(q.full(), False)
+
+        q.get()
+        self.assertEqual(q.full(), False)
+
     def test_open_close_single(self):
         """Write 1 item, close, reopen checking if same item is there"""
 

--- a/persistqueue/tests/test_sqlqueue.py
+++ b/persistqueue/tests/test_sqlqueue.py
@@ -49,6 +49,17 @@ class SQLite3QueueTest(unittest.TestCase):
         q.get()
         self.assertEqual(q.empty(), True)
 
+    def test_full(self):
+        # SQL queue `full()` always returns `False` !!
+        q = self.queue_class(self.path, auto_commit=self.auto_commit)
+        self.assertEqual(q.full(), False)
+
+        q.put('first')
+        self.assertEqual(q.full(), False)
+
+        q.get()
+        self.assertEqual(q.full(), False)
+
     def test_open_close_single(self):
         """Write 1 item, close, reopen checking if same item is there"""
 


### PR DESCRIPTION
Adds a `full()` API to complement the `empty()` API.

The `full()` API is available in Python3 `queue.Queue` class and this PR makes `persist-queue` more consistent with the `queue.Queue` API.

There doesn't seem to be a notion of a full queue when using database queues.  The `full()` API is provided for consistency and always returns `False`.