### PR TITLE
Check to see if these are empty before closing them.

### DIFF
--- a/persistqueue/sqlbase.py
+++ b/persistqueue/sqlbase.py
@@ -446,8 +446,10 @@ class SQLiteBase(SQLBase):
 
     def close(self) -> None:
         """Closes sqlite connections"""
-        self._getter.close()
-        self._putter.close()
+        if self._getter is not None:
+            self._getter.close()
+        if self._putter is not None:
+            self._putter.close()
 
     def __del__(self) -> None:
         """Handles sqlite connection when queue was deleted"""


### PR DESCRIPTION
Hello! So if I have some code like this:

```
try:
    queue = persistqueue.FIFOSQLiteQueue(path=queue_path, multithreading=True, auto_commit=False)
except sqlite3.OperationalError as e:
    logger.error("unable to create the sqlite file for the queue: %s", e)
    raise SystemExit(1)
```

But if there is an error creating the queue then I get this error:

```
[2024-06-16 00:06:13,567] ERROR    - unable to create the sqlite file for the queue: unable to open database file
Exception ignored in: <function SQLiteBase.__del__ at 0x104a0dc60>
Traceback (most recent call last):
  File "/path/to/lib/python3.12/site-packages/persistqueue/sqlbase.py", line 453, in __del__
    self._getter.close()
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'close'
```

If there is an error when creating the queue, currently it tries to close the queue but it can't because it doesn't exist. So this change checks to see if it exists before closing it.