### PR TITLE
Don't mark empty queue without max size 'full'

### DIFF
--- a/persistqueue/async_queue.py
+++ b/persistqueue/async_queue.py
@@ -138,7 +138,7 @@ class AsyncQueue:
 
     async def full(self) -> bool:
         """Check if queue is full."""
-        return await self.qsize() == self.maxsize
+        return self.maxsize > 0 and await self.qsize() == self.maxsize
 
     async def put(self, item: Any, block: bool = True,
                   timeout: Optional[float] = None) -> None:

--- a/persistqueue/queue.py
+++ b/persistqueue/queue.py
@@ -124,7 +124,7 @@ class Queue:
         return self.qsize() == 0
 
     def full(self) -> bool:
-        return self.qsize() == self.maxsize
+        return self.maxsize > 0 and self.qsize() == self.maxsize
 
     def put(self, item: Any, block: bool = True,
             timeout: Optional[float] = None) -> None:

--- a/persistqueue/tests/test_async_queue.py
+++ b/persistqueue/tests/test_async_queue.py
@@ -338,6 +338,18 @@ class TestAsyncQueue:
                 await queue.put("item_2", timeout=1.0)
 
     @pytest.mark.asyncio
+    async def test_test_full_queue_without_maxsize(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queue_path = os.path.join(temp_dir, "test_queue")
+
+            async with AsyncQueue(queue_path, maxsize=0) as queue:
+                assert await queue.full() is False
+                await queue.put("item_1")
+                assert await queue.full() is False
+                await queue.get()
+                assert await queue.full() is False
+
+    @pytest.mark.asyncio
     async def test_empty_queue_behavior(self):
         """Test empty queue behavior with blocking."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/persistqueue/tests/test_queue.py
+++ b/persistqueue/tests/test_queue.py
@@ -64,6 +64,14 @@ class TestPersist:
         q.get()
         assert q.full() is False
 
+    def test_full_without_max_size(self, queue_path):
+        q = Queue(queue_path)
+        assert q.full() is False
+        q.put('var1')
+        assert q.full() is False
+        q.get()
+        assert q.full() is False
+
     @pytest.mark.parametrize("serializer", serializer_params)
     def test_open_close_1000(self, queue_path, serializer):
         q = Queue(queue_path, **serializer)


### PR DESCRIPTION
In the current implementation, 'full' only checks if the current size is the same as the maximum, which fails as '0' is also used to mark queues without any upper limit.

This change modifies the functions to explicitly checks that a max_size is set to a value bigger than 0. Tests are added accordingly.

This closes #230